### PR TITLE
Use Maven targets for OSGi compliant artifacts from Maven-Central

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,0 +1,21 @@
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  push:
+    branches: 
+      - 'master'
+  pull_request:
+    branches: 
+     - 'master'
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-license-check:
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: modeling.tmf.xtext
+    secrets:
+      gitlabAPIToken: ${{ secrets.XTEXT_GITLAB_API_TOKEN }}

--- a/org.eclipse.xtext.p2repository/pom.xml
+++ b/org.eclipse.xtext.p2repository/pom.xml
@@ -59,7 +59,7 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>build-helper-maven-plugin</artifactId>
 					<executions>
-						<!-- sets the following properties 
+						<!-- sets the following properties
 						parsedVersion.majorVersion
 						parsedVersion.minorVersion
 						parsedVersion.incrementalVersion
@@ -316,6 +316,23 @@
 			</properties>
 			<build>
 				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-gpg-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<executions>
+							<execution>
+								<id>pgp-sign</id>
+								<phase>prepare-package</phase>
+								<goals>
+									<goal>sign-p2-artifacts</goal>
+								</goals>
+								<configuration>
+									<skipIfJarsigned>true</skipIfJarsigned>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>

--- a/xtext-latest.target
+++ b/xtext-latest.target
@@ -50,35 +50,157 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/oomph/simrel-orbit/2023-09"/>
-			<unit id="org.apache.log4j" version="1.2.24.v20221221-2012"/>
-			<unit id="org.kohsuke.args4j" version="0.0.0"/>
-			<unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
-			<unit id="com.google.guava" version="30.1.0.v20221112-0806"/>
-			<unit id="com.google.inject" version="5.0.1.v20221112-0806" />
-			<unit id="javax.inject" version="1.0.0.v20220405-0441"/>
 			<unit id="org.antlr.runtime" version="3.2.0.v20220404-1927"/>
 			<unit id="org.aopalliance" version="1.0.0.v20220404-1927"/>
-			<unit id="org.opentest4j" version="0.0.0"/>
-			<unit id="org.apiguardian.api" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.5.0"/>
-			<unit id="io.github.classgraph" version="4.8.149.v20220915-0556"/>
-			<unit id="org.slf4j.binding.simple" version="0.0.0"/>
 			<unit id="org.junit" version="4.13.2.v20211018-1956"/>
-			<unit id="junit-jupiter-api" version="0.0.0"/>
-			<unit id="junit-jupiter-engine" version="0.0.0"/>
-			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>
-			<unit id="junit-jupiter-params" version="0.0.0"/>
-			<unit id="junit-platform-commons" version="0.0.0"/>
-			<unit id="junit-platform-engine" version="0.0.0"/>
-			<unit id="junit-platform-launcher" version="0.0.0"/>
-			<unit id="junit-platform-runner" version="0.0.0"/>
-			<unit id="junit-platform-suite-api" version="0.0.0"/>
-			<unit id="junit-platform-suite-commons" version="0.0.0"/>
-			<unit id="junit-vintage-engine" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
+		</location>
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="ignore" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>args4j</groupId>
+					<artifactId>args4j</artifactId>
+					<version>2.33</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+					<version>1.2.24</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>com.google.code.gson</groupId>
+					<artifactId>gson</artifactId>
+					<version>2.10.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+					<version>30.1-jre</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>com.google.inject</groupId>
+					<artifactId>guice</artifactId>
+					<version>5.0.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>io.github.classgraph</groupId>
+					<artifactId>classgraph</artifactId>
+					<version>4.8.149</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>jakarta.inject</groupId>
+					<artifactId>jakarta.inject-api</artifactId>
+					<version>1.0.5</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.apiguardian</groupId>
+					<artifactId>apiguardian-api</artifactId>
+					<version>1.1.2</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.opentest4j</groupId>
+					<artifactId>opentest4j</artifactId>
+					<version>1.2.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.ow2.asm</groupId>
+					<artifactId>asm</artifactId>
+					<version>9.5</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-simple</artifactId>
+					<version>1.7.31</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+			<exclude>com.google.code.findbugs:jsr305:3.0.1</exclude>
+			<exclude>com.google.code.findbugs:jsr305:3.0.2</exclude>
+			<exclude>javax.inject:javax.inject:1</exclude>
+			<exclude>org.checkerframework:checker-qual:3.5.0</exclude>
+		</location>
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="JUnit (Testing)" missingManifest="error" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-api</artifactId>
+					<version>5.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-engine</artifactId>
+					<version>5.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-migrationsupport</artifactId>
+					<version>5.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-params</artifactId>
+					<version>5.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-commons</artifactId>
+					<version>1.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-engine</artifactId>
+					<version>1.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-launcher</artifactId>
+					<version>1.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-runner</artifactId>
+					<version>1.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-suite-api</artifactId>
+					<version>1.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-suite-commons</artifactId>
+					<version>1.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.vintage</groupId>
+					<artifactId>junit-vintage-engine</artifactId>
+					<version>5.9.3</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
In order to simplify consuming third-party artifacts from Maven-Central this PR aims to use a Maven-type location in the Target-Platform for all artifacts from Maven-Central that are already OSGi compliant by default.
The version of the artifacts is not updated, this is left for a follow up PR.
Furthermore Guice is not yet included because it has non-OSGi-compliant dependencies (see also https://github.com/merks/simrel-maven/issues/4).

The gpg KEYRING is already set up in the deploy workflow 
https://github.com/eclipse/xtext/blob/7ec6b4f188d35ca44d1ba2ea758e9afc61d611e2/jenkins/nightly-deploy/Jenkinsfile#L36-L46
and therefore only the gpg-sgining for the p2 repo has to be activated.

The only thing that is currently missing in this PR is the inclusion of the maven-target IUs in the Oomph-setup respectively in the workspace target location set with it.
At the moment my idea is to move all locations shared between all selectable target-platforms into a `xtext-shared.target`, which is included in all other xtext-targets as nested target and included into the Oomph targlet as composed-targets.

Additionally the Targlet-Task in the setup could be changed to conditionally include the target-file of the target-platform selected in the workspace (see https://wiki.eclipse.org/Eclipse_Oomph_Authoring#Conditional_Tasks). Actually a task for each target-file would be created, but filtered for the corresponding value of the `eclipse.target.platform` variable.
This would allow to further reduce the number of URLs defined in the setup (eventually maybe even to zero) and only specify the repo-locations once in a target-file.

This would avoid the need to declare many URLs multiple times and prevents divergence of definitions (I had the impression that in the target-files sometimes a different repository URL is used than in the Oomph-Targlet for the same project).

@cdietrich, @LorenzoBettini @szarnekow what do you think?