### PR TITLE
Allow Xtext editor subclasses to control highlighting

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -593,12 +593,18 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 		}
 	}
 
-	private void installHighlightingHelper() {
+	/**
+	 * @since 2.38
+	 */
+	protected void installHighlightingHelper() {
 		if (highlightingHelper != null)
 			highlightingHelper.install(this, (XtextSourceViewer) getSourceViewer());
 	}
 
-	private void uninstallHighlightingHelper() {
+	/**
+	 * @since 2.38
+	 */
+	protected void uninstallHighlightingHelper() {
 		if (highlightingHelper != null)
 			highlightingHelper.uninstall();
 	}


### PR DESCRIPTION
Allow Xtext editor subclasses to control highlighting, for example, to (temporarily) disable semantic highlighting in order to handle very large sources. This avoids having to resort to reflection to access these methods.

Closes https://github.com/eclipse/xtext/issues/3249