### PR TITLE
Avoid unnecessary lock on UI thread with no model listeners

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
@@ -563,6 +563,11 @@ public class XtextDocument extends Document implements IXtextDocument {
 		 *       changing while they run. To achieve this, we run the {@link IXtextModelListener}s on the UI thread.
 		 */
 		private void notifyModelListenersOnUiThread() {
+			synchronized (modelListeners) {
+				if (modelListeners.isEmpty()) {
+					return;
+				}
+			}
 			Display display = PlatformUI.getWorkbench().getDisplay();
 			if (Thread.currentThread() == display.getThread()) {
 				// We are already running on the display thread.  Run the listeners immediately.


### PR DESCRIPTION
Avoid unnecessarily aquiring a lock on the UI thread if there are no model listeners in the Xtext document.

Closes https://github.com/eclipse/xtext/issues/3251