### PR TITLE
Bugfix for Hover which is visible above other application windows. 

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseInformationControl.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseInformationControl.java
@@ -514,8 +514,6 @@ public class XbaseInformationControl extends AbstractInformationControl implemen
 	@Override
 	public void setVisible(boolean visible) {
 		Shell shell = getShell();
-		if (shell.isVisible() == visible)
-			return;
 
 		if (!visible) {
 			super.setVisible(false);
@@ -523,6 +521,9 @@ public class XbaseInformationControl extends AbstractInformationControl implemen
 			startDisposeTimeout(shell.getDisplay());
 			return;
 		}
+		
+		if (shell.isVisible() == visible)
+			return;
 
 		/*
 		 * The Browser widget flickers when made visible while it is not completely loaded.


### PR DESCRIPTION
eclipse.platform.ui https://github.com/eclipse-platform/eclipse.platform.ui/issues/2534

This patch is fixing the problem, where the HoverManagers listeners are deregistered but the hover is still visibile on top. This happens when the hover was sticky eclipse was minimized and put back on foreground after it. In that case the listeners are already deregistered and there is no chance to react at all. So for this case the visibility has to be set explicitly when the close is going to stop.
