### PR TITLE
re-export .xtext.testing

### DIFF
--- a/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.xtext;bundle-version="2.38.0",
  org.eclipse.xtext.xbase;bundle-version="2.38.0";visibility:=reexport,
  org.eclipse.jdt.core;bundle-version="3.37.0";visibility:=reexport,
  org.junit;bundle-version="4.13.2",
- org.eclipse.xtext.testing;bundle-version="2.38.0",
+ org.eclipse.xtext.testing;bundle-version="2.38.0";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="3.31.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.xtext.xbase.testing;version="2.38.0",


### PR DESCRIPTION
Closes #3271

This way, just importing .xbase.testing ensures the new `TemporaryFolder` in .xtext.testing can be found at run-time while running compilation tests 