### PR TITLE
isAutobuild without parameters, deprecated the old one

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
@@ -390,9 +390,20 @@ public class IResourcesSetupUtil {
 	public static void waitForBuild() {
 		waitForBuild(null);
 	}
-	
-	public static boolean isAutobuild(boolean enable) {
+
+	/**
+	 * @since 2.38
+	 */
+	public static boolean isAutobuild() {
 		return ResourcesPlugin.getWorkspace().getDescription().isAutoBuilding();
+	}
+
+	/**
+	 * @deprecated use {@link #isAutobuild()} instead (the boolean parameter is unused).
+	 */
+	@Deprecated(forRemoval = true)
+	public static boolean isAutobuild(boolean enable) {
+		return isAutobuild();
 	}
 
 	public static boolean setAutobuild(boolean enable) {


### PR DESCRIPTION
The boolean enable parameter was not used anyway: it must have been a copy and paste error