### PR TITLE
Fixed a few other flaky tests

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
@@ -11,6 +11,7 @@ package org.eclipse.xtend.ide.tests.compiler;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
@@ -57,7 +58,10 @@ public class QuickDebugSourceInstallingCompilationParticipantTest extends Abstra
 
 		// ensure also JDT builder finished its jobs
 		IResourcesSetupUtil.waitForBuild(
-			new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("ANOTHER BUILD"));
+				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("ANOTHER BUILD"));
+
+		source.getProject().refreshLocal(IResource.DEPTH_INFINITE,
+				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("REFRESH"));
 
 		final IFile clazz = source.getProject().getFile("bin/somePackage/Outer.class");
 		assertTrue("bytecode not found", clazz.exists());

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
@@ -32,16 +32,6 @@ public class QuickDebugSourceInstallingCompilationParticipantTest extends Abstra
 
 	@Test
 	public void testIfThereIsAnyStatum() throws Exception {
-		// ensure JDT is fully functional and its participants registered
-		workbenchTestHelper.createFile("hello/Hello.java", """
-			package hello;
-
-			public class Hello {
-			}
-		""");
-		IResourcesSetupUtil.waitForBuild(
-				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("JAVA BUILD"));
-
 		final IFile source = workbenchTestHelper.createFile("somePackage/Outer.xtend", """
 			package somePackage
 
@@ -55,10 +45,6 @@ public class QuickDebugSourceInstallingCompilationParticipantTest extends Abstra
 		""");
 		IResourcesSetupUtil.waitForBuild(
 				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("XTEND BUILD"));
-
-		// ensure also JDT builder finished its jobs
-		IResourcesSetupUtil.waitForBuild(
-				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("ANOTHER BUILD"));
 
 		source.getProject().refreshLocal(IResource.DEPTH_INFINITE,
 				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("REFRESH"));

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
@@ -38,7 +38,8 @@ public class QuickDebugSourceInstallingCompilationParticipantTest extends Abstra
 			public class Hello {
 			}
 		""");
-		IResourcesSetupUtil.waitForBuild();
+		IResourcesSetupUtil.waitForBuild(
+				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("JAVA BUILD"));
 
 		final IFile source = workbenchTestHelper.createFile("somePackage/Outer.xtend", """
 			package somePackage
@@ -51,7 +52,8 @@ public class QuickDebugSourceInstallingCompilationParticipantTest extends Abstra
 			  }
 			}
 		""");
-		IResourcesSetupUtil.waitForBuild();
+		IResourcesSetupUtil.waitForBuild(
+				new IResourcesSetupUtil.ConsoleLoggingProgressMonitor("XTEND BUILD"));
 
 		// ensure also JDT builder finished its jobs
 		IResourcesSetupUtil.waitForBuild(

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.xtend
@@ -90,6 +90,7 @@ class XtendHoverInEditorTest extends AbstractXtendUITestCase {
 		waitForBuild(null)
 		
 		val editor = openEditor(fileBar)
+		editor.waitForReconciler
 		val loggings = LoggingTester.captureLogging(Level.ERROR, AbstractBatchTypeResolver) [
 			val info = (hoverer as ITextHoverExtension2).getHoverInfo2(editor.internalSourceViewer as ITextViewer, new Region(19,1)) as XtextBrowserInformationControlInput
 			assertTrue(info.html,info.html.contains("Hello Foo"))

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.java
@@ -140,6 +140,7 @@ public class XtendHoverInEditorTest extends AbstractXtendUITestCase {
       final IFile fileBar = this.helper.createFile("Bar.xtend", contentBar);
       this._syncUtil.waitForBuild(null);
       final XtextEditor editor = this.helper.openEditor(fileBar);
+      this._syncUtil.waitForReconciler(editor);
       final Runnable _function = () -> {
         ISourceViewer _internalSourceViewer = editor.getInternalSourceViewer();
         Region _region = new Region(19, 1);

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
@@ -390,9 +390,20 @@ public class IResourcesSetupUtil {
 	public static void waitForBuild() {
 		waitForBuild(null);
 	}
-	
-	public static boolean isAutobuild(boolean enable) {
+
+	/**
+	 * @since 2.38
+	 */
+	public static boolean isAutobuild() {
 		return ResourcesPlugin.getWorkspace().getDescription().isAutoBuilding();
+	}
+
+	/**
+	 * @deprecated use {@link #isAutobuild()} instead (the boolean parameter is unused).
+	 */
+	@Deprecated(forRemoval = true)
+	public static boolean isAutobuild(boolean enable) {
+		return isAutobuild();
 	}
 
 	public static boolean setAutobuild(boolean enable) {

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/InternalBuilderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/InternalBuilderTest.java
@@ -31,12 +31,27 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.ui.texteditor.MarkerUtilities;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * @author dhuebner - Initial contribution and API
  */
 public class InternalBuilderTest {
+
+	private boolean wasAutoBuild;
+
+	@Before
+	public void saveAutoBuild() {
+		wasAutoBuild = IResourcesSetupUtil.isAutobuild();
+	}
+
+	@After
+	public void resetAutoBuild() {
+		setAutoBuild(wasAutoBuild);
+	}
 
 	@Test
 	public void test() throws CoreException, FileNotFoundException {

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/InternalBuilderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/InternalBuilderTest.java
@@ -178,7 +178,7 @@ public class InternalBuilderTest {
 		} while (wasInterrupted);
 	}
 
-	public static void setAutoBuild(boolean b) {
+	private static void setAutoBuild(boolean b) {
 		System.out.println("Setting auto-build to " + b);
 
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
@@ -263,7 +263,6 @@ public class XtextGrammarQuickfixProviderTest extends AbstractQuickfixTest {
 
 	private void assertAndApplyAllResolutions(XtextEditor xtextEditor, String issueCode, int issueDataCount, int issueCount,
 			String resolutionLabel) throws CoreException {
-		InternalBuilderTest.setAutoBuild(true);
 		if (xtextEditor.isDirty()) {
 			xtextEditor.doSave(new NullProgressMonitor());
 		}


### PR DESCRIPTION
This should remove further flakyness

* `QuickDebugSourceInstallingCompilationParticipantTest`: in the end, it looks like the problem was that the generated `.class` Eclipse resource was not fully synchronized
* Some tests did not properly reset the autobuild state