### PR TITLE
Update development environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,12 @@ The easiest way to set up a Xtext development environment is to use the followin
 
 Alternatively you can do those steps manually as follows:
 
-1. Download and start the [Eclipse Installer](https://wiki.eclipse.org/Eclipse_Oomph_Installer).
-1. On the initial page, click on the *Switch to Advanced Mode* button in the top right.
-1. On the *Product* page, select *Eclipse IDE for Eclipse Committers*.
-1. On the *Projects* page, select the *Xtext* node.
-1. Choose your preferred installation settings on the *Variables* page. Enter credentials for your Eclipse and GitHub accounts. If you don't have an SSH key registered with GitHub then make sure that you select `HTTPS (read-only, anonymous)` or `HTTPS (read-write)` for the GitHub repository entries.
-1. Finish the wizard, drink a cup of coffee, and watch how your Xtext development environment is assembled.
+1. Download and start the [Eclipse Installer](https://www.eclipse.org/downloads/packages/installer).
+2. On the initial page, open the hamburger menu and click on *Advanced Mode...*.
+3. On the *Product* page, select *Eclipse IDE for Eclipse Committers*.
+4. On the *Projects* page, select the *Xtext* node.
+5. Choose your preferred installation settings on the *Variables* page. Tick the *Show all variables* checkbox to be able to choose your preferred authentication method in the *Github Repository* drop-down menu. If you don't have an SSH key registered with GitHub then make sure that you select `HTTPS (read-only, anonymous)` or `HTTPS (read-write)`.
+6. Finish the wizard, drink a cup of coffee, and watch how your Xtext development environment is assembled.
 
 ## Contribute via a Fork
 You need a [GitHub](https://github.com/join) and an [Eclipse](https://accounts.eclipse.org/user/register) account for which you signed the [Eclipse Contributor Agreement](https://accounts.eclipse.org/user/login?destination=user/eca).


### PR DESCRIPTION
The workflow is a tad different in the newest versions of the Eclipse Installer. Also the orange badge doesn't seem to work as suggested anymore, it only opens the webpage where other buttons that actually trigger or configure the Installer can be found.