### PR TITLE
updated for the org.eclipse.xtext groupId

### DIFF
--- a/org.eclipse.xtend.m2e/lifecycle-mapping-metadata.xml
+++ b/org.eclipse.xtend.m2e/lifecycle-mapping-metadata.xml
@@ -2,7 +2,7 @@
   <pluginExecutions>
     <pluginExecution>
       <pluginExecutionFilter>
-        <groupId>org.eclipse.xtend</groupId>
+        <groupId>org.eclipse.xtext</groupId>
         <artifactId>xtend-maven-plugin</artifactId>
         <versionRange>[2.2.0,)</versionRange>
         <goals>
@@ -11,10 +11,10 @@
         </goals>
       </pluginExecutionFilter>
       <action>
-           <configurator>
-             <id>org.eclipse.xtend.m2e.xtendConfigurator</id>
-           </configurator>
-         </action>
+        <configurator>
+          <id>org.eclipse.xtend.m2e.xtendConfigurator</id>
+        </configurator>
+      </action>
     </pluginExecution>
   </pluginExecutions>
 </lifecycleMappingMetadata>

--- a/org.eclipse.xtend.m2e/lifecycle-mapping-metadata.xml
+++ b/org.eclipse.xtend.m2e/lifecycle-mapping-metadata.xml
@@ -8,6 +8,26 @@
         <goals>
           <goal>compile</goal>
           <goal>testCompile</goal>
+          <goal>xtend-test-install-debug-info</goal>
+          <goal>xtend-install-debug-info</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <configurator>
+          <id>org.eclipse.xtend.m2e.xtendConfigurator</id>
+        </configurator>
+      </action>
+    </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <groupId>org.eclipse.xtend</groupId>
+        <artifactId>xtend-maven-plugin</artifactId>
+        <versionRange>[2.2.0,)</versionRange>
+        <goals>
+          <goal>compile</goal>
+          <goal>testCompile</goal>
+          <goal>xtend-test-install-debug-info</goal>
+          <goal>xtend-install-debug-info</goal>
         </goals>
       </pluginExecutionFilter>
       <action>


### PR DESCRIPTION
Closes #3455

Unfortunately, I cannot put 2.40.0 in the version range, because we're still use SNAPSHOT