### PR TITLE
Remaining groupId org.eclipse.xtend

### DIFF
--- a/Builds.md
+++ b/Builds.md
@@ -13,13 +13,13 @@ Check the Update Site and Drop dirs to contain the new Milestone or Release
    * For milestones https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/ and https://download.eclipse.org/modeling/tmf/xtext/downloads/drops/
    * For releases https://download.eclipse.org/modeling/tmf/xtext/updates/releases/ and https://download.eclipse.org/modeling/tmf/xtext/downloads/drops/
 
-1. Promote staged milestone/release on [s01.oss.sonatype.org](https://s01.oss.sonatype.org/). Can only be done by Xtext release engineer with the right credentials at sonatype
-   * Log in with your sonatype user.
-   * Select Staging Repositories
-   * Search for orgeclipsextext-NNNN and orgeclipsextend-NNNN with status open
-   * Select both and perform the Close toolbar action
-   * Wait until the checks have run successfully
-   * Select both repositories again the perform the Release toolbar action
+1. Upload and publish milestone/release Maven artifacts on [Maven Central Repository](https://central.sonatype.com/). Can only be done by Xtext release engineer with the right credentials at sonatype
+   * For milestones navigate to <https://ci.eclipse.org/xtext/job/xtext-monorepo-full-deploy-milestone/lastSuccessfulBuild/artifact/>, for releases, navigate to <https://ci.eclipse.org/xtext/job/xtext-monorepo-full-deploy-release/lastSuccessfulBuild/artifact/>.
+   * Download the zip files from `org.eclipse.xtend.relocated.parent/target/central-publishing` and `target/central-publishing`.
+   * Go to <https://central.sonatype.com/> and log in with your sonatype user.
+   * Navigate to <https://central.sonatype.com/publishing/deployments>, press "Publish Component", and upload one of the two downloaded zip files. Do the same for the other one.
+   * For each of them, wait for the validation and press "Publish".
+   * The publishing takes several minutes.
 
 1. Contribute milestone / release to Simrel Aggregation Build
     * Clone / pull `git@github.com:eclipse-simrel/simrel.build.git`

--- a/org.eclipse.xtend.core.tests/pom.xml
+++ b/org.eclipse.xtend.core.tests/pom.xml
@@ -15,7 +15,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtend.core/pom.xml
+++ b/org.eclipse.xtend.core/pom.xml
@@ -45,7 +45,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtend.ide.common/pom.xml
+++ b/org.eclipse.xtend.ide.common/pom.xml
@@ -28,7 +28,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtend.ide.swtbot.tests/pom.xml
+++ b/org.eclipse.xtend.ide.swtbot.tests/pom.xml
@@ -13,7 +13,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/org.eclipse.xtend.ide.tests/pom.xml
+++ b/org.eclipse.xtend.ide.tests/pom.xml
@@ -13,7 +13,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/org.eclipse.xtend.ide/pom.xml
+++ b/org.eclipse.xtend.ide/pom.xml
@@ -21,7 +21,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/org.eclipse.xtend.lib.tests/pom.xml
+++ b/org.eclipse.xtend.lib.tests/pom.xml
@@ -24,7 +24,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/org.eclipse.xtend.lib/pom.xml
+++ b/org.eclipse.xtend.lib/pom.xml
@@ -27,7 +27,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtend.performance.tests/pom.xml
+++ b/org.eclipse.xtend.performance.tests/pom.xml
@@ -15,7 +15,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtext.purexbase/pom.xml
+++ b/org.eclipse.xtext.purexbase/pom.xml
@@ -13,7 +13,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtext.testing/pom.xml
+++ b/org.eclipse.xtext.testing/pom.xml
@@ -51,7 +51,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtext.tests/pom.xml
+++ b/org.eclipse.xtext.tests/pom.xml
@@ -44,7 +44,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/org.eclipse.xtext.xbase.lib.tests/pom.xml
+++ b/org.eclipse.xtext.xbase.lib.tests/pom.xml
@@ -42,7 +42,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 				<executions>
 					<!-- disable the execution for main source compile, to avoid

--- a/org.eclipse.xtext.xbase/pom.xml
+++ b/org.eclipse.xtext.xbase/pom.xml
@@ -28,7 +28,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtext.xtext.generator/pom.xml
+++ b/org.eclipse.xtext.xtext.generator/pom.xml
@@ -127,7 +127,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtext.xtext.wizard/pom.xml
+++ b/org.eclipse.xtext.xtext.wizard/pom.xml
@@ -26,7 +26,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
+				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -899,7 +899,7 @@
 					<version>3.1.0</version>
 				</plugin>
 				<plugin>
-					<groupId>org.eclipse.xtend</groupId>
+					<groupId>org.eclipse.xtext</groupId>
 					<artifactId>xtend-maven-plugin</artifactId>
 					<version>${xtend-maven-plugin-version}</version>
 					<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		This is the version of the currently released latest version of the xtend-maven-plugin that we
 		use during the Maven builds for processing Xtend files.
 		-->
-		<xtend-maven-plugin-version>2.39.0</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.40.0.M0</xtend-maven-plugin-version>
 
 		<root-dir>${basedir}/..</root-dir>
 


### PR DESCRIPTION
- bootstrap against 2.40.0.M0
- uploaded the instructions for releasing

On a side note, just for testing, the first commit only updates the xtend-maven-plugin version without changing the groupId, just to check whether the build runs fine with relocations.