### PR TITLE
fix: avoid RequestManager deadlock in LSP rename by using doSyncRead

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/InterleavingRequestManager.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/InterleavingRequestManager.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.xtext.ide.server.concurrent.RequestManager;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+
+import com.google.inject.Inject;
+
+public class InterleavingRequestManager extends RequestManager {
+	private final AtomicBoolean gateNextRead = new AtomicBoolean();
+	private final CountDownLatch readEntered = new CountDownLatch(1);
+	private final CountDownLatch continueRead = new CountDownLatch(1);
+
+	@Inject
+	public InterleavingRequestManager(ExecutorService parallel, OperationCanceledManager operationCanceledManager) {
+		super(parallel, operationCanceledManager);
+	}
+
+	public void gateNextRead() {
+		gateNextRead.set(true);
+	}
+
+	public boolean awaitReadEntered(long timeout, TimeUnit unit) throws InterruptedException {
+		return readEntered.await(timeout, unit);
+	}
+
+	public void continueRead() {
+		continueRead.countDown();
+	}
+
+	@Override
+	public synchronized <V> CompletableFuture<V> runRead(
+			Function1<? super CancelIndicator, ? extends V> cancellable) {
+		if (gateNextRead.compareAndSet(true, false)) {
+			return super.runRead((CancelIndicator cancelIndicator) -> {
+				readEntered.countDown();
+				try {
+					if (!continueRead.await(10, TimeUnit.SECONDS)) {
+						throw new AssertionError("Timed out waiting to continue read request.");
+					}
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new AssertionError(e);
+				}
+				return cancellable.apply(cancelIndicator);
+			});
+		}
+		return super.runRead(cancellable);
+	}
+}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/Rename2ConcurrencyTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/Rename2ConcurrencyTest.java
@@ -1,19 +1,20 @@
 /**
- * Copyright (c) 2017, 2020 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2026 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.xtext.ide.tests.server;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.PrepareRenameParams;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.RenameCapabilities;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
@@ -21,20 +22,26 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceEditCapabilities;
-import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.ide.server.concurrent.IRequestManager;
 import org.eclipse.xtext.testing.AbstractLanguageServerTest;
+import org.eclipse.xtext.util.Modules2;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
 
 /**
  * @author koehnlein - Initial contribution and API
  */
-public class Rename2Test extends AbstractLanguageServerTest {
-	public Rename2Test() {
+public class Rename2ConcurrencyTest extends AbstractLanguageServerTest {
+	public Rename2ConcurrencyTest() {
 		super("fileawaretestlanguage");
 	}
 
-	@Test
-	public void testRenameSelfRef() throws Exception {
+	@Test(timeout = 30000)
+	public void testRenameDoesNotDeadlockWithQueuedWrite() throws Exception {
 		String model =
 				"package foo\n" +
 				"\n" +
@@ -45,51 +52,25 @@ public class Rename2Test extends AbstractLanguageServerTest {
 		initialize();
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(file);
 		Position position = new Position(2, 9);
-		Range range = languageServer.prepareRename(new PrepareRenameParams(identifier, position)).get().getLeft();
-		assertEquals("Foo", new Document(0, model).getSubstring(range));
 		RenameParams params = new RenameParams(identifier, position, "Bar");
-		WorkspaceEdit workspaceEdit = languageServer.rename(params).get();
+		InterleavingRequestManager requestManager = (InterleavingRequestManager) languageServer.getRequestManager();
+
+		requestManager.gateNextRead();
+		CompletableFuture<WorkspaceEdit> renameResult = languageServer.rename(params);
+		Assert.assertTrue("Timed out waiting for rename read request to start.",
+				requestManager.awaitReadEntered(10, TimeUnit.SECONDS));
+		CompletableFuture<Object> writeResult = requestManager.<Object, Object>runWrite(() -> null,
+				(cancelIndicator, it) -> null);
+		requestManager.continueRead();
+
+		WorkspaceEdit workspaceEdit = renameResult.get(10, TimeUnit.SECONDS);
 		String expectation =
 				"changes :\n" +
 				"documentChanges : \n" +
 				"    Foo.fileawaretestlanguage <1> : Bar [[2, 8] .. [2, 11]]\n" +
 				"    Bar [[3, 5] .. [3, 8]]\n";
-		assertEquals(
-				expectation
-						.toString(),
-				toExpectation(workspaceEdit));
-	}
-
-	@Test
-	public void testRenameContainer() throws Exception {
-		String model =
-				"package foo\n" +
-				"\n" +
-				"element Foo {\n" +
-				" element Bar {\n" +
-				" }\n" +
-				" ref foo.Foo.Bar\n" +
-				" ref Foo.Bar\n" +
-				" ref Bar\n" +
-				"}\n";
-		String file = writeFile("foo/Foo.fileawaretestlanguage", model);
-		initialize();
-		TextDocumentIdentifier identifier = new TextDocumentIdentifier(file);
-		Position position = new Position(2, 9);
-		Range range = languageServer.prepareRename(new PrepareRenameParams(identifier, position)).get().getLeft();
-		assertEquals("Foo", new Document(0, model).getSubstring(range));
-		RenameParams params = new RenameParams(identifier, position, "Baz");
-		WorkspaceEdit workspaceEdit = languageServer.rename(params).get();
-		String expectation =
-				"changes :\n" +
-				"documentChanges : \n" +
-				"    Foo.fileawaretestlanguage <1> : Baz [[2, 8] .. [2, 11]]\n" +
-				"    Bar [[5, 5] .. [5, 16]]\n" +
-				"    Bar [[6, 5] .. [6, 12]]\n";
-		assertEquals(
-				expectation
-						.toString(),
-				toExpectation(workspaceEdit));
+		assertEquals(expectation.toString(), toExpectation(workspaceEdit));
+		writeResult.get(10, TimeUnit.SECONDS);
 	}
 
 	@Override
@@ -107,5 +88,29 @@ public class Rename2Test extends AbstractLanguageServerTest {
 			clientCapabilities.setTextDocument(textDocumentClientCapabilities);
 			params.setCapabilities(clientCapabilities);
 		});
+	}
+
+	@Override
+	protected com.google.inject.Module getServerModule() {
+		com.google.inject.Module defaultModule = super.getServerModule();
+		com.google.inject.Module customModule = new AbstractModule() {
+			@Override
+			protected void configure() {
+				bind(IRequestManager.class).to(InterleavingRequestManager.class).in(Scopes.SINGLETON);
+			}
+		};
+		return Modules2.mixin(defaultModule, customModule);
+	}
+
+	@Override
+	@After
+	public void cleanup() {
+		try {
+			super.cleanup();
+		} finally {
+			if (languageServer != null) {
+				languageServer.getRequestManager().shutdown();
+			}
+		}
 	}
 }

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/Rename2Test.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/Rename2Test.java
@@ -8,6 +8,12 @@
  */
 package org.eclipse.xtext.ide.tests.server;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -22,13 +28,69 @@ import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceEditCapabilities;
 import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.ide.server.concurrent.IRequestManager;
+import org.eclipse.xtext.ide.server.concurrent.RequestManager;
+import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.testing.AbstractLanguageServerTest;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.Modules2;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Scopes;
 
 /**
  * @author koehnlein - Initial contribution and API
  */
 public class Rename2Test extends AbstractLanguageServerTest {
+	public static class InterleavingRequestManager extends RequestManager {
+		private final AtomicBoolean gateNextRead = new AtomicBoolean();
+		private final CountDownLatch readEntered = new CountDownLatch(1);
+		private final CountDownLatch continueRead = new CountDownLatch(1);
+
+		@Inject
+		public InterleavingRequestManager(ExecutorService parallel,
+				OperationCanceledManager operationCanceledManager) {
+			super(parallel, operationCanceledManager);
+		}
+
+		public void gateNextRead() {
+			gateNextRead.set(true);
+		}
+
+		public boolean awaitReadEntered(long timeout, TimeUnit unit) throws InterruptedException {
+			return readEntered.await(timeout, unit);
+		}
+
+		public void continueRead() {
+			continueRead.countDown();
+		}
+
+		@Override
+		public synchronized <V> CompletableFuture<V> runRead(
+				Function1<? super CancelIndicator, ? extends V> cancellable) {
+			if (gateNextRead.compareAndSet(true, false)) {
+				return super.runRead((CancelIndicator cancelIndicator) -> {
+					readEntered.countDown();
+					try {
+						if (!continueRead.await(5, TimeUnit.SECONDS)) {
+							throw new AssertionError("Timed out waiting to continue read request.");
+						}
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new AssertionError(e);
+					}
+					return cancellable.apply(cancelIndicator);
+				});
+			}
+			return super.runRead(cancellable);
+		}
+	}
+
 	public Rename2Test() {
 		super("fileawaretestlanguage");
 	}
@@ -92,6 +154,39 @@ public class Rename2Test extends AbstractLanguageServerTest {
 				toExpectation(workspaceEdit));
 	}
 
+	@Test(timeout = 10000)
+	public void testRenameDoesNotDeadlockWithQueuedWrite() throws Exception {
+		String model =
+				"package foo\n" +
+				"\n" +
+				"element Foo {\n" +
+				" ref Foo\n" +
+				"}\n";
+		String file = writeFile("foo/Foo.fileawaretestlanguage", model);
+		initialize();
+		TextDocumentIdentifier identifier = new TextDocumentIdentifier(file);
+		Position position = new Position(2, 9);
+		RenameParams params = new RenameParams(identifier, position, "Bar");
+		InterleavingRequestManager requestManager = (InterleavingRequestManager) languageServer.getRequestManager();
+
+		requestManager.gateNextRead();
+		CompletableFuture<WorkspaceEdit> renameResult = languageServer.rename(params);
+		Assert.assertTrue("Timed out waiting for rename read request to start.",
+				requestManager.awaitReadEntered(2, TimeUnit.SECONDS));
+		CompletableFuture<Object> writeResult = requestManager.<Object, Object>runWrite(() -> null,
+				(cancelIndicator, it) -> null);
+		requestManager.continueRead();
+
+		WorkspaceEdit workspaceEdit = renameResult.get(5, TimeUnit.SECONDS);
+		String expectation =
+				"changes :\n" +
+				"documentChanges : \n" +
+				"    Foo.fileawaretestlanguage <1> : Bar [[2, 8] .. [2, 11]]\n" +
+				"    Bar [[3, 5] .. [3, 8]]\n";
+		assertEquals(expectation.toString(), toExpectation(workspaceEdit));
+		writeResult.get(5, TimeUnit.SECONDS);
+	}
+
 	@Override
 	protected InitializeResult initialize() {
 		return super.initialize((InitializeParams params) -> {
@@ -107,5 +202,27 @@ public class Rename2Test extends AbstractLanguageServerTest {
 			clientCapabilities.setTextDocument(textDocumentClientCapabilities);
 			params.setCapabilities(clientCapabilities);
 		});
+	}
+
+	@Override
+	protected com.google.inject.Module getServerModule() {
+		com.google.inject.Module defaultModule = super.getServerModule();
+		com.google.inject.Module customModule = new AbstractModule() {
+			@Override
+			protected void configure() {
+				bind(IRequestManager.class).to(InterleavingRequestManager.class).in(Scopes.SINGLETON);
+			}
+		};
+		return Modules2.mixin(defaultModule, customModule);
+	}
+
+	@Override
+	@After
+	public void cleanup() {
+		try {
+			super.cleanup();
+		} finally {
+			languageServer.getRequestManager().shutdown();
+		}
 	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/ChangeConverter2.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/ChangeConverter2.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.xmi.XMLResource;
@@ -83,14 +82,14 @@ public class ChangeConverter2 implements IAcceptor<IEmfResourceChange> {
 			String uri = uriExtensions.toUriString(change.getResource().getURI());
 			change.getResource().save(outputStream, null);
 			String newContent = new String(outputStream.toByteArray(), getCharset(change.getResource()));
-			access.doRead(uri, (ILanguageServerAccess.Context context) -> {
+			access.doSyncRead(uri, (ILanguageServerAccess.Context context) -> {
 				Document document = context.getDocument();
 				Range range = new Range(document.getPosition(0), document.getPosition(document.getContents().length()));
 				TextEdit textEdit = new TextEdit(range, newContent);
 				addTextEdit(uri, document, textEdit);
 				return null;
-			}).get();
-		} catch (InterruptedException | ExecutionException | IOException e) {
+			});
+		} catch (IOException e) {
 			throw Exceptions.sneakyThrow(e);
 		}
 	}
@@ -110,24 +109,20 @@ public class ChangeConverter2 implements IAcceptor<IEmfResourceChange> {
 	}
 
 	protected void _handleReplacements(ITextDocumentChange change) {
-		try {
-			if (change.getReplacements().size() > 0) {
-				String uri = uriExtensions.toUriString(change.getNewURI());
-				access.doRead(uri, (ILanguageServerAccess.Context context) -> {
-					Document document = context.getDocument();
-					List<TextEdit> textEdits = Lists.transform(change.getReplacements(),
-							(ITextReplacement replacement) -> {
-								Position start = document.getPosition(replacement.getOffset());
-								Position end = document.getPosition(replacement.getEndOffset());
-								Range range = new Range(start, end);
-								return new TextEdit(range, replacement.getReplacementText());
-							});
-					addTextEdit(uri, document, textEdits.toArray(new TextEdit[textEdits.size()]));
-					return null;
-				}).get();
-			}
-		} catch (InterruptedException | ExecutionException e) {
-			throw Exceptions.sneakyThrow(e);
+		if (change.getReplacements().size() > 0) {
+			String uri = uriExtensions.toUriString(change.getNewURI());
+			access.doSyncRead(uri, (ILanguageServerAccess.Context context) -> {
+				Document document = context.getDocument();
+				List<TextEdit> textEdits = Lists.transform(change.getReplacements(),
+						(ITextReplacement replacement) -> {
+							Position start = document.getPosition(replacement.getOffset());
+							Position end = document.getPosition(replacement.getEndOffset());
+							Range range = new Range(start, end);
+							return new TextEdit(range, replacement.getReplacementText());
+						});
+				addTextEdit(uri, document, textEdits.toArray(new TextEdit[textEdits.size()]));
+				return null;
+			});
 		}
 	}
 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/RenameService2.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/RenameService2.java
@@ -10,7 +10,6 @@ package org.eclipse.xtext.ide.server.rename;
 
 import java.io.FileNotFoundException;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EAttribute;
@@ -87,13 +86,15 @@ public class RenameService2 implements IRenameService2 {
 
 	@Override
 	public WorkspaceEdit rename(IRenameService2.Options options) {
+		boolean shouldPrepareRename = false;
 		try {
 			TextDocumentIdentifier textDocument = options.getRenameParams().getTextDocument();
 			String uri = textDocument.getUri();
 			ServerRefactoringIssueAcceptor issueAcceptor = issueProvider.get();
-			boolean shouldPrepareRename = shouldPrepareRename(options.getLanguageServerAccess());
-			return options.getLanguageServerAccess().doRead(uri, (ILanguageServerAccess.Context context) -> {
-				if (shouldPrepareRename) {
+			shouldPrepareRename = shouldPrepareRename(options.getLanguageServerAccess());
+			boolean prepareRename = shouldPrepareRename;
+			return options.getLanguageServerAccess().doSyncRead(uri, (ILanguageServerAccess.Context context) -> {
+				if (prepareRename) {
 					TextDocumentIdentifier identifier = new TextDocumentIdentifier(textDocument.getUri());
 					Position position = options.getRenameParams().getPosition();
 					PrepareRenameParams positionParams = new PrepareRenameParams(identifier, position);
@@ -131,21 +132,9 @@ public class RenameService2 implements IRenameService2 {
 				}
 				issueAcceptor.checkSeverity();
 				return workspaceEdit;
-			}).exceptionally((Throwable exception) -> {
-				try {
-					Throwable rootCause = Throwables.getRootCause(exception);
-					if (rootCause instanceof FileNotFoundException) {
-						if (shouldPrepareRename) {
-							return null;
-						}
-					}
-					throw exception;
-				} catch (Throwable e) {
-					throw Exceptions.sneakyThrow(e);
-				}
-			}).get();
-		} catch (InterruptedException | ExecutionException e) {
-			throw Exceptions.sneakyThrow(e);
+			});
+		} catch (Throwable exception) {
+			return handleReadException(exception, shouldPrepareRename);
 		}
 	}
 	
@@ -193,11 +182,13 @@ public class RenameService2 implements IRenameService2 {
 
 	@Override
 	public Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> prepareRename(IRenameService2.PrepareRenameOptions options) {
+		boolean shouldPrepareRename = false;
 		try {
 			String uri = options.getParams().getTextDocument().getUri();
-			boolean shouldPrepareRename = shouldPrepareRename(options.getLanguageServerAccess());
-			return options.getLanguageServerAccess().doRead(uri, (ILanguageServerAccess.Context context) -> {
-				if (!shouldPrepareRename) {
+			shouldPrepareRename = shouldPrepareRename(options.getLanguageServerAccess());
+			boolean prepareRename = shouldPrepareRename;
+			return options.getLanguageServerAccess().doSyncRead(uri, (ILanguageServerAccess.Context context) -> {
+				if (!prepareRename) {
 					return null;
 				}
 				Resource resource = context.getResource();
@@ -205,22 +196,20 @@ public class RenameService2 implements IRenameService2 {
 				PrepareRenameParams params = options.getParams();
 				CancelIndicator cancelIndicator = options.getCancelIndicator();
 				return doPrepareRename(resource, document, params, cancelIndicator);
-			}).exceptionally((Throwable exception) -> {
-				try {
-					Throwable rootCause = Throwables.getRootCause(exception);
-					if (rootCause instanceof FileNotFoundException) {
-						if (shouldPrepareRename) {
-							return null;
-						}
-					}
-					throw exception;
-				} catch (Throwable e) {
-					throw Exceptions.sneakyThrow(e);
-				}
-			}).get();
-		} catch (InterruptedException | ExecutionException e) {
-			throw Exceptions.sneakyThrow(e);
+			});
+		} catch (Throwable exception) {
+			return handleReadException(exception, shouldPrepareRename);
 		}
+	}
+
+	private <T> T handleReadException(Throwable exception, boolean shouldPrepareRename) {
+		Throwable rootCause = Throwables.getRootCause(exception);
+		if (rootCause instanceof FileNotFoundException) {
+			if (shouldPrepareRename) {
+				return null;
+			}
+		}
+		throw Exceptions.sneakyThrow(exception);
 	}
 
 	protected Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> doPrepareRename(Resource resource, Document document,


### PR DESCRIPTION
## Summary
LSP rename, prepareRename, and quickfix change conversion no longer queue a nested read request and block on it, which removes the `RequestManager` deadlock window: a nested read [R2] waits on a queued write [W], which awaits the in-flight outer read [R1], which waits on [R2]. The three call sites now use the existing `ILanguageServerAccess#doSyncRead`, which performs the same read without queueing.

## Why this matters
#3735 traces both in-tree paths precisely: `RenameService2.rename()` and `prepareRename()` call `doRead(uri, ...).get()` from inside the read request that `LanguageServerImpl` already queued, and `ChangeConverter2` does the same inside the code-action request. The reporter's company hits this regularly through slow quickfixes. The issue body itself proposes `doSyncRead` as the fix.

## Changes
- `RenameService2.rename()` restructures the `.exceptionally(...).get()` chain into a try/catch that preserves the existing contract: null on a root-cause `FileNotFoundException` when `shouldPrepareRename` is true, everything else rethrown via `Exceptions.sneakyThrow`.
- `ChangeConverter2` switches its `doRead(...)` + immediate join to `doSyncRead`. Every in-tree caller (the quickfix path through `DiagnosticResolution` and `QuickFixCodeActionService`) already runs inside a request and the method blocked on the future immediately, so the synchronous read is behavior-preserving apart from removing the deadlock window, answering the question the issue raised about whether the async form was ever required.

## Testing
New regression test in `Rename2Test` exercises rename while requests interleave; the existing rename, prepareRename, and code-action tests in `org.eclipse.xtext.ide.tests` stay green.

Fixes #3735
