### PR TITLE
Simplified fix: provider hint when running with junit 6 (#3750)

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/mavenTychoJUnit6.tests/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/mavenTychoJUnit6.tests/pom.xml
@@ -15,13 +15,6 @@
 				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-surefire-plugin</artifactId>
-				<configuration>
-					<providerHint>junit6</providerHint>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/mavenTychoJUnit6.ui.tests/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/mavenTychoJUnit6.ui.tests/pom.xml
@@ -20,7 +20,6 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
 					<useUIHarness>true</useUIHarness>
-					<providerHint>junit6</providerHint>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/pom.xml
@@ -167,6 +167,7 @@
 						<argLine>${platformSystemProperties} ${systemProperties} ${moduleProperties} ${additionalTestArguments}</argLine>
 						<failIfNoTests>false</failIfNoTests>
 						<useUIHarness>false</useUIHarness>
+						<providerHint>junit6</providerHint>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -11,6 +11,7 @@ package org.eclipse.xtext.xtext.wizard
 import com.google.common.io.Resources
 import java.nio.charset.StandardCharsets
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtext.util.JUnitVersion
 
 @FinalFieldsConstructor
 class ParentProjectDescriptor extends ProjectDescriptor {
@@ -416,6 +417,9 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 										<argLine>${platformSystemProperties} ${systemProperties} ${moduleProperties} ${additionalTestArguments}</argLine>
 										<failIfNoTests>false</failIfNoTests>
 										<useUIHarness>false</useUIHarness>
+										«IF config.junitVersion == JUnitVersion.JUNIT_6»
+										<providerHint>junit6</providerHint>
+										«ENDIF»
 									</configuration>
 								</plugin>
 							«ENDIF»

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
@@ -112,18 +112,6 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 								<artifactId>tycho-surefire-plugin</artifactId>
 								<configuration>
 									<useUIHarness>true</useUIHarness>
-									«IF config.junitVersion == JUnitVersion.JUNIT_6»
-										<providerHint>junit6</providerHint>
-									«ENDIF»
-								</configuration>
-							</plugin>
-						«ENDIF»
-						«IF isEclipsePluginProject && !needsUiHarness && config.junitVersion == JUnitVersion.JUNIT_6»
-							<plugin>
-								<groupId>org.eclipse.tycho</groupId>
-								<artifactId>tycho-surefire-plugin</artifactId>
-								<configuration>
-									<providerHint>junit6</providerHint>
 								</configuration>
 							</plugin>
 						«ENDIF»

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.util.JUnitVersion;
 import org.eclipse.xtext.util.XtextVersion;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -1330,6 +1331,16 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
           _builder.append("\t\t");
           _builder.append("<useUIHarness>false</useUIHarness>");
           _builder.newLine();
+          {
+            JUnitVersion _junitVersion = this.getConfig().getJunitVersion();
+            boolean _equals_1 = Objects.equals(_junitVersion, JUnitVersion.JUNIT_6);
+            if (_equals_1) {
+              _builder.append("\t\t\t");
+              _builder.append("\t\t");
+              _builder.append("<providerHint>junit6</providerHint>");
+              _builder.newLine();
+            }
+          }
           _builder.append("\t\t\t");
           _builder.append("\t");
           _builder.append("</configuration>");

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
@@ -243,46 +243,6 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
           _builder.append("\t\t");
           _builder.append("<useUIHarness>true</useUIHarness>");
           _builder.newLine();
-          {
-            JUnitVersion _junitVersion = this.getConfig().getJunitVersion();
-            boolean _equals = Objects.equals(_junitVersion, JUnitVersion.JUNIT_6);
-            if (_equals) {
-              _builder.append("\t\t");
-              _builder.append("\t\t");
-              _builder.append("<providerHint>junit6</providerHint>");
-              _builder.newLine();
-            }
-          }
-          _builder.append("\t\t");
-          _builder.append("\t");
-          _builder.append("</configuration>");
-          _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("</plugin>");
-          _builder.newLine();
-        }
-      }
-      {
-        if (((this.isEclipsePluginProject() && (!this.needsUiHarness())) && Objects.equals(this.getConfig().getJunitVersion(), JUnitVersion.JUNIT_6))) {
-          _builder.append("\t\t");
-          _builder.append("<plugin>");
-          _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("\t");
-          _builder.append("<groupId>org.eclipse.tycho</groupId>");
-          _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("\t");
-          _builder.append("<artifactId>tycho-surefire-plugin</artifactId>");
-          _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("\t");
-          _builder.append("<configuration>");
-          _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("\t\t");
-          _builder.append("<providerHint>junit6</providerHint>");
-          _builder.newLine();
           _builder.append("\t\t");
           _builder.append("\t");
           _builder.append("</configuration>");


### PR DESCRIPTION
Configure the hint only in the parent POM instead of in all the test projects

To simplify the generated POMs, as suggested https://github.com/eclipse-xtext/xtext/pull/3750#discussion_r3542097929

I also manually checked by creating a project with the wizard and I can see:

```
[INFO] [1m--- [0;32mtycho-surefire:5.0.3:test[m [1m(default-test)[m @ [36morg.xtext.example.mydsl.tests[0;1m ---[m
[INFO] Selected test framework junit (6.0.0) with provider junit6 [6.0.0,7.0.0)
```