### PR TITLE
Fix NPE in getAdapter(URI) on non-platform resource URI

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextDocument.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextDocument.java
@@ -43,7 +43,7 @@ public interface IXtextDocument extends IDocument, IDocumentExtension3, IReadAcc
 		}
 		if (IFile.class.equals(adapterType) || IResource.class.equals(adapterType)) {
 			URI resourceURI = getResourceURI();
-			if (resourceURI.isPlatformResource()) {
+			if (resourceURI != null && resourceURI.isPlatformResource()) {
 				return adapterType.cast(ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(resourceURI.toPlatformString(true))));
 			}
 		}
@@ -56,7 +56,7 @@ public interface IXtextDocument extends IDocument, IDocumentExtension3, IReadAcc
 	default public URI getResourceURI() {
 		return tryReadOnly(r -> r.getURI());
 	}
-	
+
 	public void addModelListener(IXtextModelListener listener);
 
 	public void removeModelListener(IXtextModelListener listener);


### PR DESCRIPTION
If the URI is not a platform resource (in our case: Xtext document opened for a resource inside a jar file), getAdapter(URI.class) fails with NPE below:

```
java.lang.NullPointerException: Cannot invoke
"org.eclipse.emf.common.util.URI.isPlatformResource()" because
"resourceURI" is null
	at org.eclipse.xtext.ui.editor.model.IXtextDocument.getAdapter(IXtextDocument.java:46)
	at org.eclipse.xtext.ui.editor.model.XtextDocument.getAdapter(XtextDocument.java:669)
	at org.eclipse.xtext.ui.editor.model.XtextDocument.getAdapter(XtextDocument.java:653)
```

This patch adds trivial NP check and there will be no URI adapter for unsupported resources.