### PR TITLE
Speedup of LSP Quickfix provider by caching and applying edits on-demand

### DIFF
--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/TransformationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/TransformationContextImpl.java
@@ -106,8 +106,8 @@ public class TransformationContextImpl implements TransformationContext {
     return this.getProblemSupport().getProblems(element);
   }
 
-  public void validateLater(final Procedure0 arg0) {
-    this.getProblemSupport().validateLater(arg0);
+  public void validateLater(final Procedure0 validationCallback) {
+    this.getProblemSupport().validateLater(validationCallback);
   }
 
   public MutableAnnotationTypeDeclaration findAnnotationType(final String qualifiedName) {
@@ -226,32 +226,32 @@ public class TransformationContextImpl implements TransformationContext {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
   }
 
-  public AnnotationReference newAnnotationReference(final AnnotationReference arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
   }
 
   public AnnotationReference newAnnotationReference(final Class<?> annotationClass) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass);
   }
 
-  public AnnotationReference newAnnotationReference(final Class<?> arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
   }
 
   public AnnotationReference newAnnotationReference(final String annotationTypeName) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
   }
 
-  public AnnotationReference newAnnotationReference(final String arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final String annotationTypeName, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName, initializer);
   }
 
   public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
   }
 
-  public AnnotationReference newAnnotationReference(final Type arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration, initializer);
   }
 
   public boolean exists(final Path path) {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ValidationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ValidationContextImpl.java
@@ -99,8 +99,8 @@ public class ValidationContextImpl implements ValidationContext {
     return this.getProblemSupport().getProblems(element);
   }
 
-  public void validateLater(final Procedure0 arg0) {
-    this.getProblemSupport().validateLater(arg0);
+  public void validateLater(final Procedure0 validationCallback) {
+    this.getProblemSupport().validateLater(validationCallback);
   }
 
   public MutableAnnotationTypeDeclaration findAnnotationType(final String qualifiedName) {
@@ -219,32 +219,32 @@ public class ValidationContextImpl implements ValidationContext {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
   }
 
-  public AnnotationReference newAnnotationReference(final AnnotationReference arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
   }
 
   public AnnotationReference newAnnotationReference(final Class<?> annotationClass) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass);
   }
 
-  public AnnotationReference newAnnotationReference(final Class<?> arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
   }
 
   public AnnotationReference newAnnotationReference(final String annotationTypeName) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
   }
 
-  public AnnotationReference newAnnotationReference(final String arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final String annotationTypeName, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName, initializer);
   }
 
   public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
   }
 
-  public AnnotationReference newAnnotationReference(final Type arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration, initializer);
   }
 
   public boolean exists(final Path path) {

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/quickfix/AbstractIdeQuickfixTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/quickfix/AbstractIdeQuickfixTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -37,6 +36,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolution;
+import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolutionInfo;
 import org.eclipse.xtext.ide.editor.quickfix.IQuickFixProvider;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
@@ -94,31 +94,33 @@ public abstract class AbstractIdeQuickfixTest {
 	private FileExtensionProvider fileExtensionProvider;
 
 	/**
-	 * Test that the expected quickfixes are offered on a given validation issue in a given DSL text.
+	 * Test that the expected quickfixes are offered on a given validation issue
+	 * in a given DSL text.
 	 *
-	 * @param fileContents
-	 *            The initial DSL text.
-	 * @param issueCode
-	 *            The code of the validation issue the offered quickfixes to test.
-	 * @param quickfixes
-	 *            The quickfixes that are expected to be offered on the given <code>issueCode</code>. Each expected quickfix should be described by the
-	 *            following triple:
-	 *            <ol>
-	 *            <li>the quickfix label</li>
-	 *            <li>the quickfix description</li>
-	 *            <li>the DSL text after the quickfix application</li>
-	 *            </ol>
+	 * @param fileContents The initial DSL text.
+	 * @param issueCode The code of the validation issue the offered quickfixes
+	 * to test.
+	 * @param quickfixes The quickfixes that are expected to be offered on the
+	 * given <code>issueCode</code>. Each expected quickfix should be described
+	 * by the following triple:
+	 * <ol>
+	 * <li>the quickfix label</li>
+	 * <li>the quickfix description</li>
+	 * <li>the DSL text after the quickfix application</li>
+	 * </ol>
 	 */
-	protected void assertQuickfixesOn(String fileContents, String issueCode, EClass type, QuickfixExpectation... quickfixes) {
+	protected void assertQuickfixesOn(String fileContents, String issueCode, EClass type,
+			QuickfixExpectation... quickfixes) {
 		String normalizedContents = toUnixLineSeparator(fileContents);
 		quickfixesAreOffered(createInMemoryFile(normalizedContents, type), issueCode, normalizedContents, quickfixes);
 	}
-	
-	protected void assertQuickFixOn(String fileContents, String expected, String quickFixLabel, String issueCode, EClass elementType) {
+
+	protected void assertQuickFixOn(String fileContents, String expected, String quickFixLabel, String issueCode,
+			EClass elementType) {
 		QuickfixExpectation quickfix = new QuickfixExpectation(quickFixLabel, quickFixLabel, expected);
 		assertQuickfixesOn(fileContents.toString(), issueCode, elementType, quickfix);
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	private <T> T createInMemoryFile(CharSequence content, EClass type) {
 		InMemoryURIHandler fs = new InMemoryURIHandler();
@@ -131,7 +133,8 @@ public abstract class AbstractIdeQuickfixTest {
 		return (T) quickFixTestHelper.findFirstOfTypeInFile(rs, fileName, type.getInstanceClass());
 	}
 
-	private void quickfixesAreOffered(EObject target, String issueCode, String originalText, QuickfixExpectation... expected) {
+	private void quickfixesAreOffered(EObject target, String issueCode, String originalText,
+			QuickfixExpectation... expected) {
 		List<QuickfixExpectation> expectedSorted = IterableExtensions.sortBy(Arrays.asList(expected), it -> it.label);
 		ICompositeNode elementNode = NodeModelUtils.getNode(target);
 		LineAndColumn elementStartPosition = NodeModelUtils.getLineAndColumn(elementNode, elementNode.getOffset());
@@ -156,12 +159,14 @@ public abstract class AbstractIdeQuickfixTest {
 			}
 
 			@Override
-			public <T extends Object> CompletableFuture<T> doRead(String uri, Function<ILanguageServerAccess.Context, T> function) {
+			public <T extends Object> CompletableFuture<T> doRead(String uri,
+					Function<ILanguageServerAccess.Context, T> function) {
 				return CompletableFuture.completedFuture(doSyncRead(uri, function));
 			}
 
 			@Override
-			public <T extends Object> CompletableFuture<T> doReadIndex(Function<? super ILanguageServerAccess.IndexContext, ? extends T> function) {
+			public <T extends Object> CompletableFuture<T> doReadIndex(
+					Function<? super ILanguageServerAccess.IndexContext, ? extends T> function) {
 				return null;
 			}
 
@@ -182,16 +187,16 @@ public abstract class AbstractIdeQuickfixTest {
 
 			@Override
 			public ResourceSet newLiveScopeResourceSet(URI uri) {
-				//re-using the existing ResourceSet because it contains the URI protocol mapping for "inmemory" resources.
-				ResourceSet resourceSet = options.getResource().getResourceSet();
-				return resourceSet;
+				// re-using the existing ResourceSet because it contains the URI
+				// protocol mapping for "inmemory" resources.
+				return options.getResource().getResourceSet();
 			}
 
 			@Override
 			public <T> T doSyncRead(String uri, Function<Context, T> function) {
-					ILanguageServerAccess.Context ctx = new ILanguageServerAccess.Context(options.getResource(), options.getDocument(),
-							true, CancelIndicator.NullImpl);
-					return function.apply(ctx);				
+				ILanguageServerAccess.Context ctx = new ILanguageServerAccess.Context(options.getResource(),
+						options.getDocument(), true, CancelIndicator.NullImpl);
+				return function.apply(ctx);
 			}
 		});
 		CodeActionParams codeActionParams = new CodeActionParams();
@@ -204,11 +209,9 @@ public abstract class AbstractIdeQuickfixTest {
 
 		options.setCodeActionParams(codeActionParams);
 
-		for (QuickfixExpectation expectedIssueResolution: expectedSorted) {
-			List<DiagnosticResolution> actualIssueResolutions = 
-					quickFixProvider.getResolutions(options, issue).stream()
-					.filter(r -> r.getLabel().equals(expectedIssueResolution.getLabel()))
-					.collect(Collectors.toList());
+		for (QuickfixExpectation expectedIssueResolution : expectedSorted) {
+			List<DiagnosticResolution> actualIssueResolutions = quickFixProvider.getResolutions(options, issue).stream()
+					.filter(r -> r.getLabel().equals(expectedIssueResolution.getLabel())).toList();
 			assertEquals("More than one quickfix available!", 1, actualIssueResolutions.size());
 
 			DiagnosticResolution actualIssueResolution = actualIssueResolutions.get(0);
@@ -216,15 +219,18 @@ public abstract class AbstractIdeQuickfixTest {
 			assertEquals(expectedIssueResolution.label, actualIssueResolution.getLabel());
 			assertEquals(expectedIssueResolution.description, actualIssueResolution.getLabel());
 
-			assertIssueResolutionResult(toUnixLineSeparator(expectedIssueResolution.getExpectedResult()), actualIssueResolution, originalText,
-					options.getDocument());
+			assertIssueResolutionResult(toUnixLineSeparator(expectedIssueResolution.getExpectedResult()),
+					actualIssueResolution, options.getDocument());
 		}
 	}
 
-	private void assertIssueResolutionResult(String expectedResult, DiagnosticResolution actualIssueResolution, String originalText,
+	private void assertIssueResolutionResult(String expectedResult, DiagnosticResolution actualIssueResolution,
 			Document doc) {
-		WorkspaceEdit edit = actualIssueResolution.apply();
-		List<TextEdit> edits = edit.getChanges().values().stream().flatMap(List::stream).collect(Collectors.toList());
+		String id = quickFixProvider.cacheResolution(actualIssueResolution);
+		DiagnosticResolutionInfo info = new DiagnosticResolutionInfo();
+		info.setResolutionId(id);
+		WorkspaceEdit edit = quickFixProvider.resolveResolution(info);
+		List<TextEdit> edits = edit.getChanges().values().stream().flatMap(List::stream).toList();
 		Document changedDocument = doc.applyChanges(edits);
 
 		assertEquals(expectedResult, changedDocument.getContents());

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/quickfix/TestLanguageQuickFixProvider.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/quickfix/TestLanguageQuickFixProvider.java
@@ -15,6 +15,9 @@ import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TypeDeclaration;
 import org.eclipse.xtext.ide.tests.testlanguage.validation.TestLanguageValidator;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
+import jakarta.inject.Singleton;
+
+@Singleton
 public class TestLanguageQuickFixProvider extends AbstractDeclarativeIdeQuickfixProvider {
 
 	public static String EMF_QF_LABEL = "Change element name to first upper using object modification";

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/AbstractDeclarativeIdeQuickfixProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/AbstractDeclarativeIdeQuickfixProvider.java
@@ -14,12 +14,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2.Options;
 
 import com.google.common.annotations.Beta;
@@ -27,24 +28,28 @@ import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
+import jakarta.inject.Singleton;
+
 /**
  * @author Heinrich Weichert
  *
  * @since 2.24
  */
 @Beta
+@Singleton
 public class AbstractDeclarativeIdeQuickfixProvider implements IQuickFixProvider {
 
 	private static final Logger LOG = Logger.getLogger(AbstractDeclarativeIdeQuickfixProvider.class);
 
-	private Map<String, List<Method>> methods = new ConcurrentHashMap<>();
-	
+	private final Map<String, List<Method>> methods = new ConcurrentHashMap<>();	
+	private final Map<String, DiagnosticResolution> resolutionIds = new ConcurrentHashMap<>();
+
 	@Inject
 	private Provider<DiagnosticResolutionAcceptor> issueResolutionAcceptorProvider;
 
 	private boolean getFixMethodPredicate(Method input, String issueCode) {
 		for (QuickFix annotation : input.getAnnotationsByType(QuickFix.class)) {
-			boolean result = annotation != null && Objects.equals(issueCode,annotation.value())
+			boolean result = annotation != null && Objects.equals(issueCode, annotation.value())
 					&& input.getParameterTypes().length == 1 && Void.TYPE == input.getReturnType()
 					&& input.getParameterTypes()[0].isAssignableFrom(DiagnosticResolutionAcceptor.class);
 			if (result) {
@@ -70,25 +75,25 @@ public class AbstractDeclarativeIdeQuickfixProvider implements IQuickFixProvider
 
 	private List<Method> collectMethods(Class<? extends AbstractDeclarativeIdeQuickfixProvider> clazz,
 			String issueCode) {
-		return Arrays.stream(clazz.getMethods()).filter(method -> getFixMethodPredicate(method, issueCode))
-				.collect(Collectors.toList());
+		return Arrays.stream(clazz.getMethods()).filter(method -> getFixMethodPredicate(method, issueCode)).toList();
 	}
 
 	@Override
 	public boolean handlesDiagnostic(Diagnostic diagnostic) {
-		return !getFixMethods(diagnostic).isEmpty();		
+		return !getFixMethods(diagnostic).isEmpty();
 	}
 
 	public List<Method> getFixMethods(Diagnostic diagnostic) {
-		if (diagnostic == null || diagnostic.getCode() == null || diagnostic.getMessage() == null || diagnostic.getSeverity() == null) {
+		if (diagnostic == null || diagnostic.getCode() == null || diagnostic.getMessage() == null
+				|| diagnostic.getSeverity() == null) {
 			return Collections.emptyList();
 		}
 		String issueCode = diagnostic.getCode().getLeft();
 		if (Strings.isNullOrEmpty(issueCode)) {
 			return Collections.emptyList();
 		}
-		
-		return methods.computeIfAbsent(issueCode, c -> this.collectMethods(getClass(), c));		
+
+		return methods.computeIfAbsent(issueCode, c -> this.collectMethods(getClass(), c));
 	}
 
 	/**
@@ -104,5 +109,18 @@ public class AbstractDeclarativeIdeQuickfixProvider implements IQuickFixProvider
 	 */
 	protected List<TextEdit> createTextEdit(Diagnostic diagnostic, String text) {
 		return Collections.singletonList(new TextEdit(diagnostic.getRange(), text));
+	}
+
+	@Override
+	public WorkspaceEdit resolveResolution(DiagnosticResolutionInfo info) {
+		DiagnosticResolution edit = resolutionIds.remove(info.getResolutionId());
+		return edit == null ? new WorkspaceEdit() : edit.apply();
+	}
+
+	@Override
+	public String cacheResolution(DiagnosticResolution resolution) {
+		String id = UUID.randomUUID().toString();
+		resolutionIds.put(id, resolution);
+		return id;
 	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolution.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolution.java
@@ -8,10 +8,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.editor.quickfix;
 
-import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.xtext.ide.editor.quickfix.DiagnosticModificationContext.Factory;
@@ -20,6 +18,7 @@ import org.eclipse.xtext.ide.serializer.IChangeSerializer.IModification;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
 import org.eclipse.xtext.ide.server.TextEditAcceptor;
+import org.eclipse.xtext.ide.server.UriExtensions;
 import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2.Options;
 import org.eclipse.xtext.ide.server.rename.ChangeConverter2;
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
@@ -43,23 +42,23 @@ public class DiagnosticResolution {
 	private int relevance;
 
 	private URI uri;
-	
+
 	private Document document;
-	
+
 	private ILanguageServerAccess access;
 
 	private Diagnostic diagnostic;
 
-	private static Logger log = Logger.getLogger(DiagnosticResolution.class);
+	private final UriExtensions uriExtensions = new UriExtensions();
 
-
-	@Deprecated(forRemoval=true,since="2.27")
-	public DiagnosticResolution(String label, Factory modificationContextFactory,  IModification<EObject> modification) {
+	@Deprecated(forRemoval = true, since = "2.27")
+	public DiagnosticResolution(String label, Factory modificationContextFactory, IModification<EObject> modification) {
 		this(label, modificationContextFactory, (diagnostic, object) -> modification, 0);
 	}
 
-	@Deprecated(forRemoval=true,since="2.27")
-	public DiagnosticResolution(String label, Factory modificationContextFactory,  IModification<EObject> modification, int relevance) {
+	@Deprecated(forRemoval = true, since = "2.27")
+	public DiagnosticResolution(String label, Factory modificationContextFactory, IModification<EObject> modification,
+			int relevance) {
 		this(label, modificationContextFactory, (diagnostic, object) -> modification, relevance);
 	}
 
@@ -73,7 +72,8 @@ public class DiagnosticResolution {
 	/**
 	 * @since 2.27
 	 */
-	public DiagnosticResolution(String label, Factory modificationContextFactory, ITextModification textModification, int relevance) {
+	public DiagnosticResolution(String label, Factory modificationContextFactory, ITextModification textModification,
+			int relevance) {
 		this.label = label;
 		this.factory = modificationContextFactory;
 		this.modification = null;
@@ -108,24 +108,29 @@ public class DiagnosticResolution {
 		return label;
 	}
 
-	private EObject getContextObject() {
-		ResourceSet resourceSet = access.newLiveScopeResourceSet(uri);
-		XtextResource tmpResource = (XtextResource) resourceSet.getResource(uri, true);
-		EObjectAtOffsetHelper eObjectAtOffsetHelper = tmpResource.getResourceServiceProvider().get(EObjectAtOffsetHelper.class);
-		if (eObjectAtOffsetHelper == null) {
-			return null;
-		}
-		int offset = document.getOffSet(diagnostic.getRange().getStart());
-		return eObjectAtOffsetHelper.resolveContainedElementAt(tmpResource, offset);		
+	/**
+	 * @since 2.44
+	 */
+	public URI getUri() {
+		return uri;
 	}
 
+	/**
+	 * @since 2.44
+	 */
 	public WorkspaceEdit apply() {
-		try {
-			EObject obj = getContextObject();
-			if (obj == null) {
-				return null;
-			}
+		return access.doSyncRead(uriExtensions.toUriString(uri), context -> {
+			XtextResource resource = (XtextResource) context.getResource();
+			EObjectAtOffsetHelper helper = resource.getResourceServiceProvider().get(EObjectAtOffsetHelper.class);
 			WorkspaceEdit edit = new WorkspaceEdit();
+			if (helper == null) {
+				return edit;
+			}
+			int offset = document.getOffSet(diagnostic.getRange().getStart());
+			EObject obj = helper.resolveContainedElementAt(resource, offset);
+			if (obj == null) {
+				return edit;
+			}
 			if (modification != null) {
 				DiagnosticModificationContext modificationContext = factory.createModificationContext();
 				ChangeConverter2 changeConverter = modificationContext.getConverterFactory().create(edit, access);
@@ -137,10 +142,7 @@ public class DiagnosticResolution {
 				textEditAcceptor.accept(uri.toString(), document, textModification.apply(diagnostic, obj, document));
 			}
 			return edit;
-		} catch (Exception exc) {
-			log.error("Creation of WorkspaceEdit failed.", exc);
-			return null;
-		}
+		});
 	}
 
 	void configure(Options options, Diagnostic diagnostic) {

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolutionInfo.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolutionInfo.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2026 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.quickfix;
+
+/**
+ * Contains information about the diagnostic resolution that can be applied by calling
+ * {@link IQuickFixProvider#resolveResolution(String)}
+ * 
+ * @since 2.44
+ */
+public class DiagnosticResolutionInfo {
+
+	private String resolutionId;
+	private String documentUri;
+
+	public String getResolutionId() {
+		return resolutionId;
+	}
+
+	public void setResolutionId(String resolutionId) {
+		this.resolutionId = resolutionId;
+	}
+	
+	public String getDocumentUri() {
+		return documentUri;
+	}
+
+	public void setDocumentUri(String documentUri) {
+		this.documentUri = documentUri;
+	}
+
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/IQuickFixProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/IQuickFixProvider.java
@@ -11,6 +11,7 @@ package org.eclipse.xtext.ide.editor.quickfix;
 import java.util.List;
 
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2.Options;
 
 import com.google.common.annotations.Beta;
@@ -24,8 +25,7 @@ import com.google.common.annotations.Beta;
  *
  * @since 2.24
  * 
- * Contributors: 
- *   Rubén Porras Campo (Avaloq Evolution AG) - Add method to get fix methods.
+ *        Contributors: Rubén Porras Campo (Avaloq Evolution AG) - Add method to get fix methods.
  */
 @Beta
 public interface IQuickFixProvider {
@@ -42,7 +42,6 @@ public interface IQuickFixProvider {
 	 */
 	List<DiagnosticResolution> getResolutions(Options options, Diagnostic diagnostic);
 
-	
 	/**
 	 *
 	 * If the provider handles (it has code to produce resolutions for) the given diagnostic.
@@ -56,4 +55,27 @@ public interface IQuickFixProvider {
 	default boolean handlesDiagnostic(Diagnostic diagnostic) {
 		return true;
 	}
+
+	/**
+	 * Resolves the given resolution and returns the resulting workspace edit. If the resolution is unknown, an empty
+	 * WorkspaceEdit is returned.
+	 * 
+	 * @param resolutionId
+	 *            Unique resolution retrieved from calling {@link #cacheResolution(DiagnosticResolution)}
+	 * 
+	 * @since 2.44
+	 */
+	WorkspaceEdit resolveResolution(DiagnosticResolutionInfo resolutionId);
+
+	/**
+	 * Creates a pending diagnostic resolution without applying the workspace edit
+	 * 
+	 * @see org.eclipse.xtext.ide.server.LanguageServerImpl#resolveCodeAction
+	 * 
+	 * @param resolution
+	 *            A resolution for a quickfix
+	 * 
+	 * @since 2.44
+	 */
+	String cacheResolution(DiagnosticResolution resolution);
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensOptions;
@@ -118,6 +119,8 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.findReferences.IReferenceFinder;
+import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolutionInfo;
+import org.eclipse.xtext.ide.editor.quickfix.IQuickFixProvider;
 import org.eclipse.xtext.ide.server.BuildManager.Buildable;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess.IBuildListener;
 import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2;
@@ -159,7 +162,8 @@ import com.google.inject.Inject;
  * @author Sven Efftinge - Initial contribution and API
  * @since 2.11
  */
-public class LanguageServerImpl implements LanguageServer, WorkspaceService, TextDocumentService, NotebookDocumentService, LanguageClientAware,
+public class LanguageServerImpl
+		implements LanguageServer, WorkspaceService, TextDocumentService, NotebookDocumentService, LanguageClientAware,
 		Endpoint, JsonRpcMethodProvider, ILanguageServerAccess.IBuildListener {
 
 	private static final Logger LOG = Logger.getLogger(LanguageServerImpl.class);
@@ -184,7 +188,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	@Inject
 	private SemanticTokensService semanticTokensService;
-	
+
 	private WorkspaceManager workspaceManager;
 
 	private InitializeParams initializeParams;
@@ -246,9 +250,9 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 	}
 
 	protected boolean clientSupportsWorkspaceFolders() {
-		return this.initializeParams.getCapabilities() != null 
-				&& this.initializeParams.getCapabilities().getWorkspace() != null 
-				&& Objects.equals(this.initializeParams.getCapabilities().getWorkspace().getWorkspaceFolders(), Boolean.TRUE);
+		return this.initializeParams.getCapabilities() != null
+				&& this.initializeParams.getCapabilities().getWorkspace() != null && Objects.equals(
+						this.initializeParams.getCapabilities().getWorkspace().getWorkspaceFolders(), Boolean.TRUE);
 	}
 
 	/**
@@ -278,10 +282,12 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 		serverCapabilities.setSignatureHelpProvider(new SignatureHelpOptions(ImmutableList.of("(", ",")));
 		serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
-		SemanticTokensLegend legend = new SemanticTokensLegend(semanticTokensService.getTokenTypes(), semanticTokensService.getTokenModifiers());
-		SemanticTokensWithRegistrationOptions semanticTokensWithRegistrationOptions = new SemanticTokensWithRegistrationOptions(legend);
+		SemanticTokensLegend legend = new SemanticTokensLegend(semanticTokensService.getTokenTypes(),
+				semanticTokensService.getTokenModifiers());
+		SemanticTokensWithRegistrationOptions semanticTokensWithRegistrationOptions = new SemanticTokensWithRegistrationOptions(
+				legend);
 		semanticTokensWithRegistrationOptions.setFull(true);
-		semanticTokensWithRegistrationOptions.setRange(false);		
+		semanticTokensWithRegistrationOptions.setRange(false);
 		serverCapabilities.setSemanticTokensProvider(semanticTokensWithRegistrationOptions);
 		CompletionOptions completionOptions = new CompletionOptions();
 		completionOptions.setResolveProvider(false);
@@ -403,7 +409,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 	public WorkspaceService getWorkspaceService() {
 		return this;
 	}
-	
+
 	@Override
 	public NotebookDocumentService getNotebookDocumentService() {
 		return this;
@@ -416,6 +422,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Evaluate the params and deduce the respective build command.
+	 * 
 	 * @since 2.20
 	 */
 	protected Buildable toBuildable(DidOpenTextDocumentParams params) {
@@ -589,6 +596,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Obtain the URI from the given parameters.
+	 * 
 	 * @since 2.20
 	 */
 	protected URI getURI(TextDocumentPositionParams params) {
@@ -597,6 +605,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Obtain the URI from the given identifier.
+	 * 
 	 * @since 2.20
 	 */
 	protected URI getURI(TextDocumentIdentifier documentIdentifier) {
@@ -605,6 +614,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Obtain the URI from the given document item.
+	 * 
 	 * @since 2.20
 	 */
 	protected URI getURI(TextDocumentItem documentItem) {
@@ -619,10 +629,11 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the definition. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
-	protected Either<List<? extends Location>, List<? extends LocationLink>> definition(
-			DefinitionParams params, CancelIndicator cancelIndicator) {
+	protected Either<List<? extends Location>, List<? extends LocationLink>> definition(DefinitionParams params,
+			CancelIndicator cancelIndicator) {
 		return Either.forLeft(definition(cancelIndicator, params));
 	}
 
@@ -646,6 +657,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the references. Executed in read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected List<? extends Location> references(ReferenceParams params, CancelIndicator cancelIndicator) {
@@ -669,10 +681,10 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the symbol information. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
-	protected List<DocumentSymbol> documentSymbol(DocumentSymbolParams params,
-			CancelIndicator cancelIndicator) {
+	protected List<DocumentSymbol> documentSymbol(DocumentSymbolParams params, CancelIndicator cancelIndicator) {
 		URI uri = getURI(params.getTextDocument());
 		IDocumentSymbolService documentSymbolService = getIDocumentSymbolService(getResourceServiceProvider(uri));
 		if (documentSymbolService == null) {
@@ -721,7 +733,8 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 	}
 
 	@Override
-	public CompletableFuture<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> symbol(WorkspaceSymbolParams params) {
+	public CompletableFuture<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> symbol(
+			WorkspaceSymbolParams params) {
 		return requestManager.runRead((cancelIndicator) -> {
 			List<? extends WorkspaceSymbol> symbols = symbol(params, cancelIndicator);
 			return Either.forRight(symbols);
@@ -730,10 +743,12 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the symbol information. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected List<? extends WorkspaceSymbol> symbol(WorkspaceSymbolParams params, CancelIndicator cancelIndicator) {
-		return workspaceSymbolService.getSymbols(params.getQuery(), resourceAccess, workspaceManager.getIndex(), cancelIndicator);
+		return workspaceSymbolService.getSymbols(params.getQuery(), resourceAccess, workspaceManager.getIndex(),
+				cancelIndicator);
 	}
 
 	@Override
@@ -743,6 +758,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the hover. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected Hover hover(HoverParams params, CancelIndicator cancelIndicator) {
@@ -767,6 +783,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the signature help. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected SignatureHelp signatureHelp(SignatureHelpParams params, CancelIndicator cancelIndicator) {
@@ -786,6 +803,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the document highlights. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected List<? extends DocumentHighlight> documentHighlight(DocumentHighlightParams params,
@@ -804,8 +822,27 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 		return requestManager.runRead((cancelIndicator) -> codeAction(params, cancelIndicator));
 	}
 
+	@Override
+	public CompletableFuture<CodeAction> resolveCodeAction(CodeAction action) {
+		return requestManager.<CodeAction>runRead(unused -> doResolveCodeAction(action));
+	}
+
+	protected CodeAction doResolveCodeAction(CodeAction action) {
+		if (Objects.equals(CodeActionKind.QuickFix, action.getKind())
+				&& action.getData() instanceof DiagnosticResolutionInfo info) {
+			IResourceServiceProvider serviceProvider = getResourceServiceProvider(
+					uriExtensions.toUri(info.getDocumentUri()));
+			IQuickFixProvider codeActionService = getService(serviceProvider, IQuickFixProvider.class);
+			if (codeActionService != null) {
+				action.setEdit(codeActionService.resolveResolution(info));
+			}
+		}
+		return action;
+	}
+
 	/**
 	 * Compute the code action commands. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected List<Either<Command, CodeAction>> codeAction(CodeActionParams params, CancelIndicator cancelIndicator) {
@@ -816,7 +853,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 			return Collections.emptyList();
 		}
 		ICodeActionService2.Options options = new ICodeActionService2.Options();
-		options.setURI(params.getTextDocument().getUri()); 
+		options.setURI(params.getTextDocument().getUri());
 		options.setLanguageServerAccess(access);
 		options.setCodeActionParams(params);
 		options.setCancelIndicator(cancelIndicator);
@@ -867,6 +904,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the code lenses. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected List<? extends CodeLens> codeLens(CodeLensParams params, CancelIndicator cancelIndicator) {
@@ -894,6 +932,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Resolve the given code lens. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected CodeLens resolveCodeLens(URI uri, CodeLens unresolved, CancelIndicator cancelIndicator) {
@@ -912,6 +951,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Create the text edits for the formatter. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected List<? extends TextEdit> formatting(DocumentFormattingParams params, CancelIndicator cancelIndicator) {
@@ -931,6 +971,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Create the text edits for the formatter. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected List<? extends TextEdit> rangeFormatting(DocumentRangeFormattingParams params,
@@ -980,6 +1021,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Execute the command. Runs in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected Object executeCommand(ExecuteCommandParams params, CancelIndicator cancelIndicator) {
@@ -998,6 +1040,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 
 	/**
 	 * Compute the rename edits. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
 	protected WorkspaceEdit rename(RenameParams renameParams, CancelIndicator cancelIndicator) {
@@ -1028,16 +1071,18 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 	 * @since 2.18
 	 */
 	@Override
-	public CompletableFuture<Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> prepareRename(PrepareRenameParams params) {
+	public CompletableFuture<Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> prepareRename(
+			PrepareRenameParams params) {
 		return requestManager.runRead(cancelIndicator -> prepareRename(params, cancelIndicator));
 	}
 
 	/**
 	 * Prepare the rename operation. Executed in a read request.
+	 * 
 	 * @since 2.20
 	 */
-	protected Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> prepareRename(PrepareRenameParams params,
-			CancelIndicator cancelIndicator) {
+	protected Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> prepareRename(
+			PrepareRenameParams params, CancelIndicator cancelIndicator) {
 		URI uri = getURI(params);
 		IRenameService2 renameService = getService(uri, IRenameService2.class);
 		if (renameService == null) {
@@ -1066,8 +1111,8 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 		if (foldingRangeService == null) {
 			return Lists.newArrayList();
 		}
-		return workspaceManager.doRead(uri, (document, resource) -> foldingRangeService
-				.createFoldingRanges(document, resource, cancelIndicator));
+		return workspaceManager.doRead(uri,
+				(document, resource) -> foldingRangeService.createFoldingRanges(document, resource, cancelIndicator));
 	}
 
 	@Override
@@ -1197,7 +1242,8 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 	};
 
 	/**
-	 * @deprecated please register a {@link IBuildListener} directly through {@link ILanguageServerAccess#addBuildListener(IBuildListener)}
+	 * @deprecated please register a {@link IBuildListener} directly through
+	 *             {@link ILanguageServerAccess#addBuildListener(IBuildListener)}
 	 */
 	@Override
 	@Deprecated

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/codeActions/QuickFixCodeActionService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/codeActions/QuickFixCodeActionService.java
@@ -20,6 +20,7 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.ide.editor.quickfix.AbstractDeclarativeIdeQuickfixProvider;
 import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolution;
+import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolutionInfo;
 import org.eclipse.xtext.ide.editor.quickfix.IQuickFixProvider;
 import org.eclipse.xtext.ide.editor.quickfix.QuickFix;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
@@ -42,7 +43,7 @@ public class QuickFixCodeActionService implements ICodeActionService2 {
 
 	@Inject
 	private IQuickFixProvider quickfixes;
-
+	
 	@Override
 	public List<Either<Command, CodeAction>> getCodeActions(Options options) {
 		boolean handleQuickfixes = options.getCodeActionParams().getContext().getOnly() == null
@@ -55,9 +56,12 @@ public class QuickFixCodeActionService implements ICodeActionService2 {
 
 		List<Either<Command, CodeAction>> result = new ArrayList<>();
 		for (Diagnostic diagnostic : options.getCodeActionParams().getContext().getDiagnostics()) {
+			if (options.getCancelIndicator().isCanceled()) {
+				break;
+			}
 			if (handlesDiagnostic(diagnostic)) {
-				result.addAll(options.getLanguageServerAccess()
-						.doSyncRead(options.getURI(), (ILanguageServerAccess.Context context) -> {
+				result.addAll(options.getLanguageServerAccess().doSyncRead(options.getURI(),
+						(ILanguageServerAccess.Context context) -> {
 							options.setDocument(context.getDocument());
 							options.setResource(context.getResource());
 							return getCodeActions(options, diagnostic);
@@ -80,20 +84,29 @@ public class QuickFixCodeActionService implements ICodeActionService2 {
 	protected List<Either<Command, CodeAction>> getCodeActions(Options options, Diagnostic diagnostic) {
 		List<Either<Command, CodeAction>> codeActions = new ArrayList<>();
 		quickfixes.getResolutions(options, diagnostic).stream()
-				.sorted(Comparator
-						.nullsLast(Comparator.comparing(DiagnosticResolution::getLabel)))
+				.sorted(Comparator.nullsLast(Comparator.comparing(DiagnosticResolution::getLabel)))
 				.forEach(r -> codeActions.add(Either.forRight(createFix(r, diagnostic))));
 		return codeActions;
 	}
-	
+
+	/**
+	 * @since 2.28 Creates a new quick-fix without applying the modification. The textual edit can be composed by calling
+	 *        DiagnosticResolution#apply().
+	 */
 	private CodeAction createFix(DiagnosticResolution resolution, Diagnostic diagnostic) {
 		CodeAction codeAction = new CodeAction();
 		codeAction.setDiagnostics(Collections.singletonList(diagnostic));
 		codeAction.setTitle(resolution.getLabel());
-		codeAction.setEdit(resolution.apply());
 		codeAction.setKind(CodeActionKind.QuickFix);
-
+		codeAction.setData(createResolutionInfo(resolution));
 		return codeAction;
+	}
+
+	private DiagnosticResolutionInfo createResolutionInfo(DiagnosticResolution resolution) {
+		DiagnosticResolutionInfo info = new DiagnosticResolutionInfo();
+		info.setResolutionId(quickfixes.cacheResolution(resolution));
+		info.setDocumentUri(resolution.getUri().toString());
+		return info;
 	}
 
 }

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -3,11 +3,12 @@
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package org.eclipse.xtext.testing
 
+import com.google.common.annotations.Beta
 import com.google.inject.Guice
 import com.google.inject.Inject
 import com.google.inject.Module
@@ -20,6 +21,7 @@ import java.util.List
 import java.util.Map
 import java.util.concurrent.CompletableFuture
 import org.eclipse.emf.common.util.URI
+import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionContext
 import org.eclipse.lsp4j.CodeActionParams
@@ -56,6 +58,7 @@ import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.ReferenceContext
 import org.eclipse.lsp4j.ReferenceParams
 import org.eclipse.lsp4j.ResourceOperation
+import org.eclipse.lsp4j.SemanticTokensParams
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SignatureHelpParams
 import org.eclipse.lsp4j.SymbolInformation
@@ -64,8 +67,10 @@ import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+import org.eclipse.lsp4j.WorkspaceClientCapabilities
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.WorkspaceSymbol
 import org.eclipse.lsp4j.WorkspaceSymbolParams
 import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.jsonrpc.messages.Either
@@ -93,16 +98,11 @@ import org.junit.jupiter.api.BeforeEach
 
 import static extension org.eclipse.lsp4j.util.Ranges.containsRange
 import static extension org.eclipse.xtext.util.Strings.*
-import org.eclipse.lsp4j.WorkspaceSymbol
-import org.eclipse.lsp4j.SemanticTokensParams
-import com.google.common.annotations.Beta
-import org.eclipse.lsp4j.ClientCapabilities
-import org.eclipse.lsp4j.WorkspaceClientCapabilities
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  *         Rubén Porras Campo - Semantic Tokens Full
- 
+ *  
  */
 @FinalFieldsConstructor
 abstract class AbstractLanguageServerTest implements Endpoint {
@@ -143,22 +143,22 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	protected def Class<? extends LanguageClient> getLanguageClientClass() {
 		return LanguageClient;
 	}
-	
+
 	/**
 	 * A request manager that will run the given read and write actions in the same thread immediately, sequentially.
 	 */
 	@Singleton
 	static class DirectRequestManager extends AbstractRequestManager {
-	
+
 		@Inject
 		new(OperationCanceledManager operationCanceledManager) {
 			super(operationCanceledManager)
 		}
-		
+
 		override synchronized <V> runRead((CancelIndicator)=>V request) {
 			val result = new CompletableFuture()
 			try {
-				result.complete(request.apply [ false ])
+				result.complete(request.apply[false])
 			} catch (Throwable t) {
 				if (isCancelException(t)) {
 					result.cancel(true)
@@ -182,11 +182,11 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 			}
 			return result
 		}
-		
+
 		override shutdown() {
 			// no shutdown
 		}
-		
+
 	}
 
 	protected def Module getServerModule() {
@@ -222,12 +222,13 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	protected def InitializeResult initialize((InitializeParams)=>void initializer) {
 		initialize(initializer, true)
 	}
-	
+
 	protected def InitializeResult initialize((InitializeParams)=>void initializer, boolean callInitialized) {
 		initialize(initializer, callInitialized, false)
 	}
-	
-	protected def InitializeResult initialize((InitializeParams)=>void initializer, boolean callInitialized, boolean useRootPath) {
+
+	protected def InitializeResult initialize((InitializeParams)=>void initializer, boolean callInitialized,
+		boolean useRootPath) {
 		val params = new InitializeParams => [
 			processId = 1
 			workspaceFolders = #[
@@ -310,17 +311,18 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 			«element.toExpectation»
 		«ENDFOR»
 	'''
+
 	protected def dispatch String toExpectation(String it) { it }
-	
+
 	protected def dispatch String toExpectation(Integer it) { '''«it»''' }
-	
+
 	protected def dispatch String toExpectation(Void it) { '' }
 
 	protected dispatch def String toExpectation(Either<?, ?> either) '''
 		«IF either.isLeft»
-		«either.getLeft.toExpectation»
+			«either.getLeft.toExpectation»
 		«ELSE»
-		«either.getRight.toExpectation»
+			«either.getRight.toExpectation»
 		«ENDIF»
 	'''
 
@@ -355,8 +357,9 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	 * @since 2.16
 	 */
 	protected def dispatch String toExpectation(DocumentSymbol it) {
-		Assert.assertTrue('''selectionRange must be contained in the range: «it»''', range.containsRange(selectionRange))
-	'''
+		Assert.assertTrue('''selectionRange must be contained in the range: «it»''',
+			range.containsRange(selectionRange))
+		'''
 		symbol "«name»" {
 		    kind: «kind.value»
 		    range: «range.toExpectation»
@@ -364,9 +367,9 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		    details: «detail»
 		    deprecated: «deprecated»
 		    «IF !children.nullOrEmpty»
-		    children: [
-		    	«FOR child : children SEPARATOR'\n'»«child.toExpectation»«ENDFOR»
-		    ]
+		    	children: [
+		    		«FOR child : children SEPARATOR'\n'»«child.toExpectation»«ENDFOR»
+		    	]
 		    «ENDIF»
 		}'''
 	}
@@ -392,8 +395,10 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 			return '<empty>';
 		}
 		Assert.assertNotNull('Active signature index must not be null when signatures are available.', activeSignature);
-		val param = if(activeParameter === null) '<empty>' else signatures.get(activeSignature).parameters.get(
-				activeParameter).label.getLeft();
+		val param = if (activeParameter === null)
+				'<empty>'
+			else
+				signatures.get(activeSignature).parameters.get(activeParameter).label.getLeft();
 		'''«signatures.map[label].join(' | ')» | «param»''';
 	}
 
@@ -405,17 +410,17 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	protected dispatch def String toExpectation(DocumentHighlightKind kind) {
 		return kind.toString.substring(0, 1).toUpperCase;
 	}
-	
+
 	protected dispatch def String toExpectation(Map<Object, Object> it) {
 		val sb = new StringBuilder;
-		entrySet.forEach[
+		entrySet.forEach [
 			if (sb.length > 0) {
 				sb.append('\n');
 			}
 			sb.append(key.toExpectation);
 			sb.append(' ->');
 			if (value instanceof Iterable<?>) {
-				(value as Iterable<?>).forEach[
+				(value as Iterable<?>).forEach [
 					sb.append('\n * ');
 					sb.append(toExpectation);
 				]
@@ -423,14 +428,14 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 				sb.append(' ');
 				sb.append(value.toExpectation);
 			}
- 		];
+		];
 		return sb.toString;
 	}
 
 	protected dispatch def String toExpectation(CodeLens it) {
-		return command.title + " " +range.toExpectation
+		return command.title + " " + range.toExpectation
 	}
-	
+
 	protected dispatch def String toExpectation(FoldingRange it) {
 		return '''[«String.valueOf(kind)» «startLine»..«endLine»]'''
 	}
@@ -445,7 +450,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
 		val filePath = initializeContext(configuration).uri
-		val codeLenses = languageServer.codeLens(new CodeLensParams=>[
+		val codeLenses = languageServer.codeLens(new CodeLensParams => [
 			textDocument = new TextDocumentIdentifier(filePath)
 		])
 		val result = codeLenses.get.map[languageServer.resolveCodeLens(it).get].toList
@@ -456,7 +461,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 			assertEquals(expectedCodeLensItems, result.toExpectation)
 		}
 	}
-	
+
 	protected dispatch def String toExpectation(MarkupContent it) '''
 		kind: «kind»
 		value: «value»
@@ -486,32 +491,30 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 				«ENDFOR»
 			«ENDIF»
 	'''
-	
+
 	protected dispatch def String toExpectation(ResourceOperation it) '''
 		kind : «kind»
 	'''
-	
-	protected dispatch def String toExpectation(CodeAction it)  '''
+
+	protected dispatch def String toExpectation(CodeAction it) '''
 		title : «title»
 		kind : «kind»
 		command : «command»
 		«IF !diagnostics.nullOrEmpty»codes : «diagnostics.map[code.get].join(',')»«ENDIF»
 		edit : «edit.toExpectation»
 	'''
-	
+
 	protected def dispatch String toExpectation(TextDocumentEdit e) '''
 		«e.textDocument.toExpectation» : «e.edits.toExpectation»
 	'''
 
-	protected def dispatch String toExpectation(VersionedTextDocumentIdentifier v) 
-		'''«URI.createURI(v.uri).lastSegment» <«v.version»>'''
-	
-	
-	
+	protected def dispatch String toExpectation(
+		VersionedTextDocumentIdentifier v) '''«URI.createURI(v.uri).lastSegment» <«v.version»>'''
+
 	@Accessors static class TestCodeActionConfiguration extends TextDocumentPositionConfiguration {
 		String expectedCodeActions = ''
 
-		(List<Either<Command, CodeAction>>)=>void assertCodeActions= null
+		(List<Either<Command, CodeAction>>)=>void assertCodeActions = null
 	}
 
 	@Beta
@@ -532,7 +535,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
 		val filePath = initializeContext(configuration).uri
-		val result = languageServer.codeAction(new CodeActionParams=>[
+		val result = languageServer.codeAction(new CodeActionParams => [
 			textDocument = new TextDocumentIdentifier(filePath)
 			range = new Range => [
 				start = new Position(configuration.line, configuration.column)
@@ -542,11 +545,13 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 				diagnostics = this.diagnostics.get(filePath)
 			]
 		])
+		val actions = result.get
+		actions.filter[getRight !== null].forEach[e|languageServer.resolveCodeAction(e.getRight).get]
 
 		if (configuration.assertCodeActions !== null) {
 			configuration.assertCodeActions.apply(result.get)
 		} else {
-			assertEquals(configuration.expectedCodeActions, result.get.toExpectation)
+			assertEquals(configuration.expectedCodeActions, actions.toExpectation)
 		}
 	}
 
@@ -561,7 +566,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		])
 
 		val result = completionItems.get
-		val items = if (result.isLeft) result.getLeft else result.getRight.items
+		val items = if(result.isLeft) result.getLeft else result.getRight.items
 		// assert ordered by sortText
 		Assert.assertEquals(items, items.sortBy[sortText].toList)
 		if (configuration.assertCompletionList !== null) {
@@ -733,7 +738,8 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		testFormatting(null, configurator)
 	}
 
-	protected def testFormatting((DocumentFormattingParams)=>void paramsConfigurator, (FormattingConfiguration)=>void configurator) {
+	protected def testFormatting((DocumentFormattingParams)=>void paramsConfigurator,
+		(FormattingConfiguration)=>void configurator) {
 		val extension configuration = new FormattingConfiguration
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
@@ -753,7 +759,8 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		testRangeFormatting(null, configurator)
 	}
 
-	protected def testRangeFormatting((DocumentRangeFormattingParams)=>void paramsConfigurator, (RangeFormattingConfiguration)=>void configurator) {
+	protected def testRangeFormatting((DocumentRangeFormattingParams)=>void paramsConfigurator,
+		(RangeFormattingConfiguration)=>void configurator) {
 		val extension configuration = new RangeFormattingConfiguration
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
@@ -770,7 +777,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		val result = new Document(1, fileInfo.contents).applyChanges(<TextEdit>newArrayList(changes.get()).reverse)
 		assertEqualsStricter(configuration.expectedText, result.contents)
 	}
-	
+
 	/**
 	 * @since 2.26
 	 */
@@ -778,13 +785,13 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		val extension configuration = new FoldingConfiguration
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
-		
+
 		val fileInfo = initializeContext(configuration)
-		
+
 		val foldings = languageServer.foldingRange(new FoldingRangeRequestParams => [
 			textDocument = new TextDocumentIdentifier(fileInfo.uri)
 		]).get()
-		
+
 		assertEqualsStricter(configuration.expectedFoldings, foldings.toExpectation);
 	}
 
@@ -797,14 +804,13 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	}
 
 	protected def Map<String, List<Diagnostic>> getDiagnostics() {
-		languageServer.requestManager.runRead[
+		languageServer.requestManager.runRead [
 			val result = <String, List<Diagnostic>>newHashMap
 			for (diagnostic : notifications.map[value].filter(PublishDiagnosticsParams)) {
 				result.put(diagnostic.uri, diagnostic.diagnostics)
 			}
-			return result 
+			return result
 		].get
 	}
 
 }
-

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -630,7 +630,8 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("selectionRange must be contained in the range: ");
       _builder.append(it);
-      Assert.assertTrue(_builder.toString(), Ranges.containsRange(it.getRange(), it.getSelectionRange()));
+      Assert.assertTrue(_builder.toString(), 
+        Ranges.containsRange(it.getRange(), it.getSelectionRange()));
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("symbol \"");
       String _name = it.getName();
@@ -785,8 +786,7 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       if (_tripleEquals_1) {
         _xifexpression = "<empty>";
       } else {
-        _xifexpression = it.getSignatures().get((it.getActiveSignature()).intValue()).getParameters().get(
-          (it.getActiveParameter()).intValue()).getLabel().getLeft();
+        _xifexpression = it.getSignatures().get((it.getActiveSignature()).intValue()).getParameters().get((it.getActiveParameter()).intValue()).getLabel().getLeft();
       }
       final String param = _xifexpression;
       StringConcatenation _builder_1 = new StringConcatenation();
@@ -1134,10 +1134,23 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       };
       CodeActionParams _doubleArrow = ObjectExtensions.<CodeActionParams>operator_doubleArrow(_codeActionParams, _function);
       final CompletableFuture<List<Either<Command, CodeAction>>> result = this.languageServer.codeAction(_doubleArrow);
+      final List<Either<Command, CodeAction>> actions = result.get();
+      final Function1<Either<Command, CodeAction>, Boolean> _function_1 = (Either<Command, CodeAction> it) -> {
+        CodeAction _right = it.getRight();
+        return Boolean.valueOf((_right != null));
+      };
+      final Consumer<Either<Command, CodeAction>> _function_2 = (Either<Command, CodeAction> e) -> {
+        try {
+          this.languageServer.resolveCodeAction(e.getRight()).get();
+        } catch (Throwable _e) {
+          throw Exceptions.sneakyThrow(_e);
+        }
+      };
+      IterableExtensions.<Either<Command, CodeAction>>filter(actions, _function_1).forEach(_function_2);
       if ((configuration.assertCodeActions != null)) {
         configuration.assertCodeActions.apply(result.get());
       } else {
-        this.assertEquals(configuration.expectedCodeActions, this.toExpectation(result.get()));
+        this.assertEquals(configuration.expectedCodeActions, this.toExpectation(actions));
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -1560,64 +1573,64 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
   }
 
   @XbaseGenerated
-  protected String toExpectation(final Object it) {
-    if (it instanceof Integer) {
-      return _toExpectation((Integer)it);
-    } else if (it instanceof List) {
-      return _toExpectation((List<?>)it);
-    } else if (it instanceof DocumentHighlightKind) {
-      return _toExpectation((DocumentHighlightKind)it);
-    } else if (it instanceof String) {
-      return _toExpectation((String)it);
-    } else if (it instanceof VersionedTextDocumentIdentifier) {
-      return _toExpectation((VersionedTextDocumentIdentifier)it);
-    } else if (it == null) {
+  protected String toExpectation(final Object elements) {
+    if (elements instanceof List) {
+      return _toExpectation((List<?>)elements);
+    } else if (elements instanceof Integer) {
+      return _toExpectation((Integer)elements);
+    } else if (elements instanceof DocumentHighlightKind) {
+      return _toExpectation((DocumentHighlightKind)elements);
+    } else if (elements instanceof String) {
+      return _toExpectation((String)elements);
+    } else if (elements instanceof VersionedTextDocumentIdentifier) {
+      return _toExpectation((VersionedTextDocumentIdentifier)elements);
+    } else if (elements == null) {
       return _toExpectation((Void)null);
-    } else if (it instanceof Map) {
-      return _toExpectation((Map<Object, Object>)it);
-    } else if (it instanceof CodeAction) {
-      return _toExpectation((CodeAction)it);
-    } else if (it instanceof CodeLens) {
-      return _toExpectation((CodeLens)it);
-    } else if (it instanceof Command) {
-      return _toExpectation((Command)it);
-    } else if (it instanceof CompletionItem) {
-      return _toExpectation((CompletionItem)it);
-    } else if (it instanceof DocumentHighlight) {
-      return _toExpectation((DocumentHighlight)it);
-    } else if (it instanceof DocumentSymbol) {
-      return _toExpectation((DocumentSymbol)it);
-    } else if (it instanceof FoldingRange) {
-      return _toExpectation((FoldingRange)it);
-    } else if (it instanceof Hover) {
-      return _toExpectation((Hover)it);
-    } else if (it instanceof Location) {
-      return _toExpectation((Location)it);
-    } else if (it instanceof MarkupContent) {
-      return _toExpectation((MarkupContent)it);
-    } else if (it instanceof Position) {
-      return _toExpectation((Position)it);
-    } else if (it instanceof Range) {
-      return _toExpectation((Range)it);
-    } else if (it instanceof ResourceOperation) {
-      return _toExpectation((ResourceOperation)it);
-    } else if (it instanceof SignatureHelp) {
-      return _toExpectation((SignatureHelp)it);
-    } else if (it instanceof SymbolInformation) {
-      return _toExpectation((SymbolInformation)it);
-    } else if (it instanceof TextDocumentEdit) {
-      return _toExpectation((TextDocumentEdit)it);
-    } else if (it instanceof TextEdit) {
-      return _toExpectation((TextEdit)it);
-    } else if (it instanceof WorkspaceEdit) {
-      return _toExpectation((WorkspaceEdit)it);
-    } else if (it instanceof WorkspaceSymbol) {
-      return _toExpectation((WorkspaceSymbol)it);
-    } else if (it instanceof Either) {
-      return _toExpectation((Either<?, ?>)it);
+    } else if (elements instanceof Map) {
+      return _toExpectation((Map<Object, Object>)elements);
+    } else if (elements instanceof CodeAction) {
+      return _toExpectation((CodeAction)elements);
+    } else if (elements instanceof CodeLens) {
+      return _toExpectation((CodeLens)elements);
+    } else if (elements instanceof Command) {
+      return _toExpectation((Command)elements);
+    } else if (elements instanceof CompletionItem) {
+      return _toExpectation((CompletionItem)elements);
+    } else if (elements instanceof DocumentHighlight) {
+      return _toExpectation((DocumentHighlight)elements);
+    } else if (elements instanceof DocumentSymbol) {
+      return _toExpectation((DocumentSymbol)elements);
+    } else if (elements instanceof FoldingRange) {
+      return _toExpectation((FoldingRange)elements);
+    } else if (elements instanceof Hover) {
+      return _toExpectation((Hover)elements);
+    } else if (elements instanceof Location) {
+      return _toExpectation((Location)elements);
+    } else if (elements instanceof MarkupContent) {
+      return _toExpectation((MarkupContent)elements);
+    } else if (elements instanceof Position) {
+      return _toExpectation((Position)elements);
+    } else if (elements instanceof Range) {
+      return _toExpectation((Range)elements);
+    } else if (elements instanceof ResourceOperation) {
+      return _toExpectation((ResourceOperation)elements);
+    } else if (elements instanceof SignatureHelp) {
+      return _toExpectation((SignatureHelp)elements);
+    } else if (elements instanceof SymbolInformation) {
+      return _toExpectation((SymbolInformation)elements);
+    } else if (elements instanceof TextDocumentEdit) {
+      return _toExpectation((TextDocumentEdit)elements);
+    } else if (elements instanceof TextEdit) {
+      return _toExpectation((TextEdit)elements);
+    } else if (elements instanceof WorkspaceEdit) {
+      return _toExpectation((WorkspaceEdit)elements);
+    } else if (elements instanceof WorkspaceSymbol) {
+      return _toExpectation((WorkspaceSymbol)elements);
+    } else if (elements instanceof Either) {
+      return _toExpectation((Either<?, ?>)elements);
     } else {
       throw new IllegalArgumentException("Unhandled parameter types: " +
-        Arrays.<Object>asList(it).toString());
+        Arrays.<Object>asList(elements).toString());
     }
   }
 

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/controlflow/EvaluationResult.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/controlflow/EvaluationResult.java
@@ -195,6 +195,9 @@ class EvaluationResult implements IConstantEvaluationResult<Object> {
     } else if (myValue instanceof JvmFormalParameter
          && otherValue instanceof JvmFormalParameter) {
       return _equalValue((JvmFormalParameter)myValue, (JvmFormalParameter)otherValue);
+    } else if (myValue instanceof List
+         && otherValue instanceof List) {
+      return _equalValue((List<?>)myValue, (List<?>)otherValue);
     } else if (myValue instanceof JvmType
          && otherValue instanceof XTypeLiteral) {
       return _equalValue((JvmType)myValue, (XTypeLiteral)otherValue);
@@ -207,6 +210,9 @@ class EvaluationResult implements IConstantEvaluationResult<Object> {
     } else if (myValue instanceof JvmType
          && otherValue instanceof JvmIdentifiableElement) {
       return _equalValue((JvmType)myValue, (JvmIdentifiableElement)otherValue);
+    } else if (myValue instanceof List
+         && otherValue == null) {
+      return _equalValue((List<?>)myValue, (Void)null);
     } else if (myValue instanceof JvmType
          && otherValue == null) {
       return _equalValue((JvmType)myValue, (Void)null);
@@ -216,30 +222,27 @@ class EvaluationResult implements IConstantEvaluationResult<Object> {
     } else if (myValue instanceof XTypeLiteral
          && otherValue instanceof ThisReference) {
       return _equalValue((XTypeLiteral)myValue, (ThisReference)otherValue);
+    } else if (myValue instanceof List
+         && otherValue != null) {
+      return _equalValue((List<?>)myValue, otherValue);
     } else if (myValue instanceof JvmIdentifiableElement
          && otherValue instanceof JvmEnumerationLiteral) {
       return _equalValue((JvmIdentifiableElement)myValue, (JvmEnumerationLiteral)otherValue);
     } else if (myValue instanceof JvmIdentifiableElement
          && otherValue instanceof JvmType) {
       return _equalValue((JvmIdentifiableElement)myValue, (JvmType)otherValue);
-    } else if (myValue instanceof List
-         && otherValue instanceof List) {
-      return _equalValue((List<?>)myValue, (List<?>)otherValue);
     } else if (myValue instanceof JvmIdentifiableElement
          && otherValue instanceof JvmIdentifiableElement) {
       return _equalValue((JvmIdentifiableElement)myValue, (JvmIdentifiableElement)otherValue);
-    } else if (myValue instanceof List
-         && otherValue == null) {
-      return _equalValue((List<?>)myValue, (Void)null);
     } else if (myValue instanceof JvmIdentifiableElement
          && otherValue == null) {
       return _equalValue((JvmIdentifiableElement)myValue, (Void)null);
-    } else if (myValue instanceof List
-         && otherValue != null) {
-      return _equalValue((List<?>)myValue, otherValue);
     } else if (myValue instanceof JvmIdentifiableElement
          && otherValue != null) {
       return _equalValue((JvmIdentifiableElement)myValue, otherValue);
+    } else if (myValue == null
+         && otherValue instanceof List) {
+      return _equalValue((Void)null, (List<?>)otherValue);
     } else if (myValue == null
          && otherValue instanceof JvmType) {
       return _equalValue((Void)null, (JvmType)otherValue);
@@ -249,9 +252,6 @@ class EvaluationResult implements IConstantEvaluationResult<Object> {
     } else if (myValue instanceof ThisReference
          && otherValue instanceof XTypeLiteral) {
       return _equalValue((ThisReference)myValue, (XTypeLiteral)otherValue);
-    } else if (myValue == null
-         && otherValue instanceof List) {
-      return _equalValue((Void)null, (List<?>)otherValue);
     } else if (myValue == null
          && otherValue instanceof JvmIdentifiableElement) {
       return _equalValue((Void)null, (JvmIdentifiableElement)otherValue);


### PR DESCRIPTION
Fixes https://github.com/eclipse-xtext/xtext/issues/3665

Rationale: Text edits for quickfixes shall be computed _only_ when needed. This is achieved by first collecting and then later resolving the quickfixes. This avoids creating a lot of unneeded overhead.

`codeLens` and `resolveCodeLens`