### PR TITLE
[Build] Leverage fix env variable matching in maven-toolchains-plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,15 +66,8 @@ pipeline {
       steps {
         xvnc(useXauthority: true) {
           sh """
-            jdkEnvVar='JAVA_${javaVersion()}_HOME'
-            if [ "${JAVA_HOME}" = "\${JAVA_${javaVersion()}_HOME}" ]; then
-              # Workaround for https://github.com/apache/maven-toolchains-plugin/pull/148
-              # clear the structured variable and require JAVA_HOME instead
-              export JAVA_${javaVersion()}_HOME=''
-              jdkEnvVar='JAVA_HOME'
-            fi
             ./full-build.sh --tp=${params.TARGET_PLATFORM} \
-              -Pstrict-jdk-${javaVersion()} -Dtoolchain.jdk.env=\${jdkEnvVar}
+              -Pstrict-jdk-${javaVersion()} -Dtoolchain.jdk.env=JAVA_${javaVersion()}_HOME
           """
         }
       }// END steps

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-toolchains-plugin</artifactId>
-					<version>3.2.0</version>
+					<version>3.3.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Since https://github.com/apache/maven-toolchains-plugin/pull/148 is now fixed and the `maven-toolchains-plugin` version `3.3.0` is about to be released the pipeline can be simplified by removing now unnecessary workarounds.

I've verified this again at the m2e Jenkins instance (https://ci.eclipse.org/m2e/job/try-outs-xtext-Hannes/) using the current RC from:
- https://www.mail-archive.com/dev@maven.apache.org/msg137905.html

Once the vote is completed and the release is published this can be applied and I'll convert this to ready for review.

Additionally I've also considered to remove the `strict-jdk-X` profiles because at least for the Jenkins use-case they are actually not necessary anymore. However they are also used in the github workflows and can also be useful for local builds if one wants to continue to use the classical approach based on a Maven `toolchains.xml` file (which can be more convenient for local builds).
