### PR TITLE
Use root type name when generating Java example runtime test

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/JUnitFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/JUnitFragment.xtend
@@ -186,7 +186,7 @@ class JUnitFragment extends AbstractStubGeneratingFragment {
 				
 				@«test»
 				public void loadModel() throws Exception {
-					Model result = parseHelper.parse("Hello Xtext!");
+					«rootType» result = parseHelper.parse("Hello Xtext!");
 					«assert».assertNotNull(result);
 					«list»<«diagnostic»> errors = result.eResource().getErrors();
 					«IF junitVersion==JUnitVersion.JUNIT_4»

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/JUnitFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/JUnitFragment.java
@@ -411,7 +411,7 @@ public class JUnitFragment extends AbstractStubGeneratingFragment {
         _builder.append("public void loadModel() throws Exception {");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append(rootType, "\t");
+        _builder.append(rootType, "\t\t");
         _builder.append(" result = parseHelper.parse(\"Hello Xtext!\");");
         _builder.newLine();
         _builder.append("\t\t");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/JUnitFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/JUnitFragment.java
@@ -411,7 +411,8 @@ public class JUnitFragment extends AbstractStubGeneratingFragment {
         _builder.append("public void loadModel() throws Exception {");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("Model result = parseHelper.parse(\"Hello Xtext!\");");
+        _builder.append(rootType, "\t");
+        _builder.append(" result = parseHelper.parse(\"Hello Xtext!\");");
         _builder.newLine();
         _builder.append("\t\t");
         _builder.append(assert_, "\t\t");


### PR DESCRIPTION
Use root type name when generating Java example runtime test.

There was still a hard-coded `Model`, which doesn't compile when another name is used.

```java
public class KisekiTcgParsingTest {
	@Inject
	private ParseHelper<Domainmodel> parseHelper;

	@Test
	public void loadModel() throws Exception {
		Model result = parseHelper.parse("Hello Xtext!");
		Assertions.assertNotNull(result);
		List<Diagnostic> errors = result.eResource().getErrors();
		Assertions.assertTrue(errors.isEmpty(), "Unexpected errors: " + IterableExtensions.join(errors, ", "));
	}
}
```