### PR TITLE
org.eclipse.update.install.sources=false

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -336,8 +336,7 @@
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
-      label="Tools"
-      profileProperties="">
+      label="Tools">
     <requirement
         name="org.eclipse.m2e.feature.feature.group"/>
   </setupTask>
@@ -345,8 +344,7 @@
       xsi:type="setup.p2:P2Task"
       id="p2.swtbot"
       label="SWTBot"
-      licenseConfirmationDisabled="true"
-      profileProperties="">
+      licenseConfirmationDisabled="true">
     <requirement
         name="org.eclipse.swtbot.eclipse.feature.group"/>
     <requirement

--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -337,7 +337,7 @@
   <setupTask
       xsi:type="setup.p2:P2Task"
       label="Tools"
-      profileProperties="org.eclipse.update.install.sources=false">
+      profileProperties="">
     <requirement
         name="org.eclipse.m2e.feature.feature.group"/>
   </setupTask>
@@ -346,7 +346,7 @@
       id="p2.swtbot"
       label="SWTBot"
       licenseConfirmationDisabled="true"
-      profileProperties="org.eclipse.update.install.sources=false">
+      profileProperties="">
     <requirement
         name="org.eclipse.swtbot.eclipse.feature.group"/>
     <requirement

--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -314,7 +314,8 @@
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
-      label="Eclipse">
+      label="Eclipse"
+      profileProperties="org.eclipse.update.install.sources=false">
     <requirement
         name="org.eclipse.emf.sdk.feature.group"/>
     <requirement
@@ -335,7 +336,8 @@
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
-      label="Tools">
+      label="Tools"
+      profileProperties="org.eclipse.update.install.sources=false">
     <requirement
         name="org.eclipse.m2e.feature.feature.group"/>
   </setupTask>
@@ -343,7 +345,8 @@
       xsi:type="setup.p2:P2Task"
       id="p2.swtbot"
       label="SWTBot"
-      licenseConfirmationDisabled="true">
+      licenseConfirmationDisabled="true"
+      profileProperties="org.eclipse.update.install.sources=false">
     <requirement
         name="org.eclipse.swtbot.eclipse.feature.group"/>
     <requirement


### PR DESCRIPTION
org.eclipse.update.install.sources=false

To prevent source features from being installed in the IDE.

See also https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3448#issuecomment-4944608840