### PR TITLE
Don't refer to non-API WorkbenchMessages removed from 4.42 SDK

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/FixedScopedPreferenceStore.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/FixedScopedPreferenceStore.java
@@ -355,7 +355,7 @@ public class FixedScopedPreferenceStore extends EventManager implements IPersist
 				Assert
 						.isTrue(
 								false,
-								org.eclipse.ui.internal.WorkbenchMessages.ScopedPreferenceStore_DefaultAddedError);
+								"Do not add the default to the search contexts");
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse-xtext/xtext/issues/3791